### PR TITLE
Fix downloads badge linking to raw SVG image instead of releases page

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -7,7 +7,7 @@
 ![](https://img.shields.io/github/v/release/shenaba/2s-ui.svg)
 [![Container image](https://img.shields.io/badge/container-ghcr.io%2Fshenaba%2F2s--ui-blue?logo=docker)](https://github.com/shenaba/2s-ui/actions/workflows/docker.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/shenaba/2s-ui)](https://goreportcard.com/report/github.com/shenaba/2s-ui)
-[![Downloads](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)
+[![Downloads](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)](https://github.com/shenaba/2s-ui/releases)
 [![License](https://img.shields.io/badge/license-GPL%20V3-blue.svg?longCache=true)](https://www.gnu.org/licenses/gpl-3.0.en.html)
 
 > **سلب مسئولیت:** این پروژه تنها برای یادگیری و تبادل نظر شخصی است؛ لطفاً از آن برای مقاصد غیرقانونی استفاده نکنید و آن را در محیط تولیدی (production) به کار نگیرید.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![](https://img.shields.io/github/v/release/shenaba/2s-ui.svg)
 [![Container image](https://img.shields.io/badge/container-ghcr.io%2Fshenaba%2F2s--ui-blue?logo=docker)](https://github.com/shenaba/2s-ui/actions/workflows/docker.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/shenaba/2s-ui)](https://goreportcard.com/report/github.com/shenaba/2s-ui)
-[![Downloads](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)
+[![Downloads](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)](https://github.com/shenaba/2s-ui/releases)
 [![License](https://img.shields.io/badge/license-GPL%20V3-blue.svg?longCache=true)](https://www.gnu.org/licenses/gpl-3.0.en.html)
 
 > **Disclaimer:** This project is only for personal learning and communication, please do not use it for illegal purposes, please do not use it in a production environment

--- a/README.ru.md
+++ b/README.ru.md
@@ -7,7 +7,7 @@
 ![](https://img.shields.io/github/v/release/shenaba/2s-ui.svg)
 [![Container image](https://img.shields.io/badge/container-ghcr.io%2Fshenaba%2F2s--ui-blue?logo=docker)](https://github.com/shenaba/2s-ui/actions/workflows/docker.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/shenaba/2s-ui)](https://goreportcard.com/report/github.com/shenaba/2s-ui)
-[![Downloads](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)
+[![Downloads](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)](https://github.com/shenaba/2s-ui/releases)
 [![License](https://img.shields.io/badge/license-GPL%20V3-blue.svg?longCache=true)](https://www.gnu.org/licenses/gpl-3.0.en.html)
 
 > **Отказ от ответственности:** Этот проект предназначен только для личного обучения и общения. Пожалуйста, не используйте его в незаконных целях и не используйте его в производственной среде.

--- a/README.vi.md
+++ b/README.vi.md
@@ -6,7 +6,7 @@
 ![](https://img.shields.io/github/v/release/shenaba/2s-ui.svg)
 [![Container image](https://img.shields.io/badge/container-ghcr.io%2Fshenaba%2F2s--ui-blue?logo=docker)](https://github.com/shenaba/2s-ui/actions/workflows/docker.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/shenaba/2s-ui)](https://goreportcard.com/report/github.com/shenaba/2s-ui)
-[![Downloads](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)
+[![Downloads](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)](https://github.com/shenaba/2s-ui/releases)
 [![License](https://img.shields.io/badge/license-GPL%20V3-blue.svg?longCache=true)](https://www.gnu.org/licenses/gpl-3.0.en.html)
 
 > **Tuyên bố miễn trừ trách nhiệm:** Dự án này chỉ dành cho mục đích học tập và trao đổi cá nhân, vui lòng không sử dụng cho các mục đích bất hợp pháp, vui lòng không sử dụng trong môi trường production

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 ![](https://img.shields.io/github/v/release/shenaba/2s-ui.svg)
 [![Container image](https://img.shields.io/badge/container-ghcr.io%2Fshenaba%2F2s--ui-blue?logo=docker)](https://github.com/shenaba/2s-ui/actions/workflows/docker.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/shenaba/2s-ui)](https://goreportcard.com/report/github.com/shenaba/2s-ui)
-[![Downloads](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)
+[![Downloads](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)](https://github.com/shenaba/2s-ui/releases)
 [![License](https://img.shields.io/badge/license-GPL%20V3-blue.svg?longCache=true)](https://www.gnu.org/licenses/gpl-3.0.en.html)
 
 > **免责声明：** 本项目仅供个人学习与交流使用，请勿用于非法用途，请勿用于生产环境。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -9,7 +9,7 @@
 ![](https://img.shields.io/github/v/release/shenaba/2s-ui.svg)
 [![Container image](https://img.shields.io/badge/container-ghcr.io%2Fshenaba%2F2s--ui-blue?logo=docker)](https://github.com/shenaba/2s-ui/actions/workflows/docker.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/shenaba/2s-ui)](https://goreportcard.com/report/github.com/shenaba/2s-ui)
-[![Downloads](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)
+[![Downloads](https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg)](https://github.com/shenaba/2s-ui/releases)
 [![License](https://img.shields.io/badge/license-GPL%20V3-blue.svg?longCache=true)](https://www.gnu.org/licenses/gpl-3.0.en.html)
 
 > **免責聲明：** 本專案僅供個人學習與交流使用，請勿用於非法用途，請勿用於正式環境。


### PR DESCRIPTION
## Problem

Clicking the **downloads** badge in the README threw an error. The badge's link target pointed at the raw shields.io SVG image URL (`https://img.shields.io/github/downloads/shenaba/2s-ui/total.svg`) instead of a real page. Opening that raw SVG URL in the GitHub mobile app's in-app browser results in an error.

All other badges (Container image, Go Report, License) correctly link to real pages — only the downloads badge linked back to its own image.

## Fix

Point the downloads badge link to the releases page (`https://github.com/shenaba/2s-ui/releases`), which is where download counts come from. Applied to all six README translations:

- README.md
- README.fa.md
- README.ru.md
- README.vi.md
- README.zh-CN.md
- README.zh-TW.md

https://claude.ai/code/session_019eq1RtZSKufSFJCQDroJHQ

---
_Generated by [Claude Code](https://claude.ai/code/session_019eq1RtZSKufSFJCQDroJHQ)_