### PR TITLE
ci: vet and build on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+# The only gate that runs on a pull request. release.yml and windows.yml do build
+# on push to main -- their path filters do cover **.go, go.mod and go.sum -- but
+# only once the merge has landed, and by way of the full seven-platform release
+# matrix. This runs on the PR instead, in one cheap job. (docker.yml has no push
+# trigger at all, so a Dockerfile change stays ungated until a release.)
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: build (linux/amd64)
+    runs-on: ubuntu-latest
+    env:
+      # Same tags release.yml uses for its non-naive platforms. The naive tags are
+      # left out on purpose: they need the Chromium/cronet toolchain, which costs
+      # minutes to fetch and adds nothing to a compile gate.
+      BUILD_TAGS: with_quic,with_grpc,with_utls,with_acme,with_gvisor,badlinkname,tfogo_checklinkname0,with_tailscale
+    steps:
+      # No submodules: the frontend is not needed to compile the backend. web/html
+      # is gitignored, and web.go's `//go:embed *` matches web.go itself, so the
+      # embed resolves without a frontend build.
+      - name: Checkout repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Vet
+        run: go vet -tags "$BUILD_TAGS" ./...
+
+      # -checklinkname=0 is required, not cosmetic: sing-box's badtls references
+      # unexported crypto/tls internals, and the link fails without it with
+      # "invalid reference to crypto/tls.(*Conn).handlePostHandshakeMessage".
+      - name: Build
+        run: go build -ldflags="-w -s -checklinkname=0" -tags "$BUILD_TAGS" -o /dev/null .


### PR DESCRIPTION
Nothing runs on a pull request today.

`release.yml` and `windows.yml` do build on push to `main` — their path filters cover `**.go`, `go.mod` and `go.sum`, so a dependency bump is compiled — but only once the merge has landed, and by way of the full seven-platform release matrix with the Chromium/cronet toolchains behind it. A bad bump is found on `main`, minutes later, rather than on the PR. `docker.yml` has no push trigger at all, so a Dockerfile change stays ungated until a release is published.

## What it runs

One job on `pull_request` and on push to `main`: `go vet ./...` then `go build`, for linux/amd64 only. Deliberately a compile gate, not a release rehearsal:

- **No submodules.** The frontend is not needed to compile the backend: `web/html` is gitignored, and `web.go`'s `//go:embed *` matches `web.go` itself, so the embed resolves without a frontend build. The frontend has its own CI in its own repo (shenaba/2s-ui-frontend#14).
- **The naive tags are left out.** They need the Chromium/cronet toolchain that `release.yml` spends minutes fetching, and add nothing to a compile check. The rest of the tag set is exactly what `release.yml` builds for its non-naive platforms.
- **`-checklinkname=0` is required, not cosmetic.** Without it the link fails on sing-box's `badtls`, which references unexported `crypto/tls` internals:
  ```
  link: github.com/sagernet/sing-box/common/badtls: invalid reference to
  crypto/tls.(*Conn).handlePostHandshakeMessage
  ```

## Verification

Both commands were run locally against `GOOS=linux` with the exact tag set and flags in the workflow, and both pass — so this should not land red. The dropped-`-checklinkname=0` failure above is from actually removing it and watching the link break, not from reading the docs.

The workflow itself is exercised by this PR: `pull_request` means the check you see on this page **is** the thing under review.

## Follow-up worth considering

`docker.yml` still has no pre-release gate. A Dockerfile change is first built when a release is published, which is the worst possible time to find out — this is why the Dockerfile was left alone in the armv6 investigation. Adding a build-only (no push) Docker job on PRs would close that, but it needs buildx/QEMU for the arm platforms and is a bigger job than this one.
