### PR TITLE
fix(frontend): bump vue-router to 5.2.0 for the pinia 4 peer range

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,176 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+2S-UI is a sing-box web panel — a maintained fork of `alireza0/s-ui`. Module path: `github.com/shenaba/2s-ui`.
+
+Two facts shape almost everything else:
+
+1. **sing-box is embedded as a Go library, not supervised as a subprocess.** `core/` wraps it directly (`core.Box` reimplements sing-box's own `box.Box` so the panel can inject its own trackers). Restarting "the core" is an in-process object teardown, not a process kill.
+2. **The frontend compiles into the Go binary.** `frontend/dist/` → `web/html/` → `//go:embed *` in [web/web.go](web/web.go). There is one deployable artifact: `sui`.
+
+## Commands
+
+Go toolchain per `go.mod`: **1.26.4** (`CONTRIBUTING.md` says 1.25 — go.mod is authoritative; CI uses `go-version-file: go.mod`). CGO is required for the SQLite driver.
+
+```bash
+./build.sh          # frontend (npm i && npm run build) -> web/html -> go build -o sui
+./runSUI.sh         # build.sh, then SUI_DB_FOLDER="db" SUI_DEBUG=true ./sui
+```
+
+Panel: http://localhost:2095/app/ (`admin`/`admin`). Sub server: :2096.
+
+### Reproducing the PR gate locally
+
+`ci.yml` is the only thing that runs on a PR, and it is exactly these three commands:
+
+```bash
+export BUILD_TAGS=with_quic,with_grpc,with_utls,with_acme,with_gvisor,badlinkname,tfogo_checklinkname0,with_tailscale
+go vet -tags "$BUILD_TAGS" ./...
+go build -ldflags="-w -s -checklinkname=0" -tags "$BUILD_TAGS" -o /dev/null .
+cd frontend && npm ci && npm run build   # = vue-tsc --noEmit && vite build; type errors fail the build
+```
+
+`-checklinkname=0` is **required, not cosmetic**: sing-box's `badtls` references unexported `crypto/tls` internals, and the link otherwise fails with `invalid reference to crypto/tls.(*Conn).handlePostHandshakeMessage`.
+
+The Go build does not need the frontend — `web/html` is gitignored and the `//go:embed *` pattern matches `web.go` itself, so it resolves even with no frontend built.
+
+**`npm ci` is not what ships — the PR gate is the only thing that uses it.** It installs the lockfile verbatim and never re-resolves the tree, so it does not enforce peer ranges. Every path that actually produces a binary (`release.yml`, `windows.yml`, `Dockerfile`, `build.sh`, `windows/build-windows.ps1`) runs `npm install`, which *does* re-resolve. **A dependency bump can therefore be green on CI and still break every shipping path with `ERESOLVE`.** That is exactly how pinia 4 reached main: `vue-router` declared `peerOptional pinia@^3.0.4`, `npm ci` never looked, and `release.yml` died in 13s on the merge commit. Before trusting CI on a dependency PR:
+
+```bash
+cd frontend && npm install --package-lock-only   # re-resolves; catches what npm ci hides
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm run dev      # vite --host on :3000 (frontend/CONTRIBUTING.md's ":5173" is wrong)
+npm run lint     # eslint . --fix
+```
+
+`npm run dev` proxies `/app/api` → `localhost:2095`. In DEV only, a custom axios adapter falls back to `src/plugins/mock.ts` when the backend is down (the vite proxy turns `ECONNREFUSED` into a 502, which the adapter reads as "not running") — so **the UI silently renders fake data if you forget to start the Go side**.
+
+### Tests
+
+**There are none.** Zero `*_test.go` in the repo, no frontend unit tests. CI gates compilation and types only. Verification is: build, run, exercise the changed area by hand (both themes, mobile ≤820px, `fa` RTL for UI work). Don't claim a change is tested because CI is green.
+
+### Build tags
+
+Release tags: the CI set above, plus `with_naive_outbound,with_musl` on platforms where cronet ships. `core/register_*.go` / `register_*_stub.go` pair every optional protocol with a stub behind `//go:build !tag`, so **dropping `with_naive_outbound` and/or `with_tailscale` still compiles and runs** — those protocols just return "rebuild with -tags ..." at runtime. Useful when the cronet/Chromium toolchain isn't available locally.
+
+Note the tag sets legitimately differ per target: `Dockerfile` uses `with_purego` and omits `badlinkname`/`-checklinkname=0`; `windows/build-windows.ps1` is narrower than `windows.yml`, so a local Windows build is **not** feature-equivalent to the released one.
+
+## Architecture
+
+### Package map — only the names that mislead
+
+The rest (`api/`, `service/`, `util/`, `cmd/`, `cronjob/`, `logger/`, `middleware/`, `windows/`) mean what they say; `ls` is enough. These don't:
+
+| Path | What it actually is |
+|---|---|
+| `config/` | **No sing-box config here.** Only `//go:embed`ed version/name, `SUI_*` env vars, and DB/cert path resolution. The real config is assembled from the DB at runtime (below). |
+| `database/` vs `db/` | `database/` is code (GORM + `model/`). `db/` is the runtime SQLite data dir (gitignored). |
+| `sub/` | Not a subpackage of `web/` — an independent second gin server on :2096 with its own listen/port/domain/cert settings. |
+| `network/` | Not protocol code — ACME issuance, TLS config, and a listener that sniffs the first packet: plaintext HTTP hitting the HTTPS port gets a 307 to `https://`, anything else falls through to the TLS handshake. |
+| `app/` | One file. Lifecycle orchestration only (DB → settings → core → cron → both servers). |
+| `core/` | The sing-box wrapper. Business logic lives in `service/`. |
+
+### The config assembly loop (the central mechanism)
+
+The sing-box config is **not a file**. It is assembled per start from the database:
+
+```
+settings.config (base JSON: log/dns/ntp/route/experimental)
+  + inbounds/outbounds/services/endpoints tables (each row -> one JSON object)
+  = SingBoxConfig -> json.Marshal -> core.Start(rawConfig)
+```
+
+This lives in `ConfigService.GetConfig` ([service/config.go](service/config.go)). Consequences worth internalizing:
+
+- Editing an entity means editing a **DB row**, then restarting the core. `ConfigService.Save` is the single write path: it opens a transaction, dispatches by object type, writes a `Changes` audit row, and bumps `LastUpdate` (which drives the frontend's `api/changes` poll).
+- `StartCore` is guarded by `startCoreMu` + a 15s `startCooldown` after a failure, and a `@every 5s` cron job (`checkCoreJob`) restarts the core if it's down. A failed config does not permanently wedge the panel, but it also means **your bad config will be retried on a loop** — read the log, don't just re-save.
+
+### Model pattern: fixed columns + `Options` blob
+
+`database/model/` entities (`Inbound`, `Outbound`, `Service`, `Endpoint`) promote only the fields the panel needs into real columns (`Id`, `Type`, `Tag`, `TlsId`, `Addrs`, `OutJson`) and stuff **everything else** into an `Options json.RawMessage`. Custom `UnmarshalJSON` splits incoming JSON that way; then there are two marshalling shapes:
+
+- `MarshalJSON` → **sing-box shape** (type/tag/tls + spread `Options`) — what gets fed to the core.
+- `MarshalFull` → **panel shape** (adds `id`, `tls_id`, `addrs`, `out_json`) — what the API returns to the UI.
+
+So a new sing-box protocol field usually needs **no Go change** — it rides along in `Options`. It needs a frontend type in `frontend/src/types/` and a form component. That's why those types are snake_case: they serialize straight to sing-box JSON.
+
+### Process shape
+
+[app/app.go](app/app.go) `APP.Init/Start/Stop` wires and owns everything: DB → settings → `core.Core` → cronjobs → **two independent gin servers**:
+
+- `web.Server` (:2095) — panel SPA + `api` + `apiv2`.
+- `sub.Server` (:2096) — subscription delivery only, `GET/HEAD /:subid`.
+
+Both are separately configurable (listen/port/domain/cert) and each independently supports ACME. `main.go` runs the panel only when `len(os.Args) < 2`; otherwise it dispatches to `cmd.ParseCmd()`. `SIGHUP` triggers `RestartApp()`.
+
+### The two APIs share one service
+
+`api/apiHandler.go` (v1) and `api/apiV2Handler.go` (v2) are **action-dispatch switches over a shared `ApiService`**, not REST. Both route `POST /:action` + `GET /:action`.
+
+- **v1** = session cookie (`gin-contrib/sessions`), used by the SPA.
+- **v2** = `Token` header, checked against an in-memory token slice; mutations via v1 (`addToken`/`deleteToken`) must call `apiv2.ReloadTokens()`.
+
+Adding an endpoint = adding a `case` to the switch **and** a method on `ApiService`. Response convention throughout is `{success, msg, obj}` (`Msg` in `frontend/src/plugins/httputil.ts`).
+
+There is **no per-entity endpoint**: every mutation is `POST api/save` with `{object, action, data}`. On the frontend, that's `Data().save(object, action, data)` in `store/modules/data.ts`.
+
+### The BASE_URL loop
+
+The panel path is a **runtime DB setting**, not a build constant. This spans five files and is easy to break:
+
+1. `web.go` reads `GetWebPath()` and renders the built `index.html` **as a Go template** with `{"BASE_URL": base_url}`.
+2. `frontend/index.html` ships `window.BASE_URL = "{{ .BASE_URL }}"`, falling back to `/app/` if the first char is `{` (i.e. unrendered → dev mode). Vite doesn't touch inline script bodies, so the Go template survives the bundle.
+3. `vite.config.mts` sets `base: ''` (relative asset URLs), `router` uses `createWebHistory(window.BASE_URL)`, and `plugins/api.ts` sets `axios.defaults.baseURL = "./"`.
+
+**Never hardcode `/app/` and never make axios paths absolute** — it breaks both custom web paths and dev mode.
+
+Related: `vite.config.mts` gives assets **random filenames per build** (not content hashes), because `web.go` serves `assets/` with `Cache-Control: max-age=31536000`.
+
+### Auth
+
+`meta.requiresAuth` in the router is declared but **never read**. Enforcement is server-side on full page load (`web.go`'s `NoRoute` redirects to `login`), plus a reactive client-side catch: any `{success:false, msg:"Invalid login"}` response triggers logout in `httputil.ts`. Session is cookie-based; no token is stored client-side.
+
+### Stats & clients
+
+`core.StatsTracker`/`ConnTracker` are appended to sing-box's router as trackers; a `@every 10s` cron job flushes counters into the `stats` table, bucketed by a unique index on `(resource, tag, date_time, direction)`. Clients hold `Inbounds` as a JSON id array — the "multi-inbound per user" model the project is built around — and editing a client diffs the inbound set and hot-restarts only affected inbounds (`InboundService.RestartInbounds`).
+
+### Version & migrations
+
+`config/version` (currently **1.5.5**) is `//go:embed`ed — **not** injected via `-X` ldflags. Bumping a release means editing that file in-tree; the git tag and the embedded version can drift. `cmd/migration/` gates on the **2s-ui** version line, not upstream's (users' `dbVersion` tracks 2s-ui releases) — see the comment in `cmd/migration/main.go` before adding one.
+
+### `sui` CLI
+
+`sui -v` · `admin` (`-show/-reset/-username/-password`) · `uri` · `migrate` · `setting` (`-port/-path/-subPort/-subPath`) · `backup` (`-output`, `-exclude=changes,stats`). All except `-v` need a resolvable DB path (`SUI_DB_FOLDER`, else relative to `argv[0]`).
+
+## Frontend conventions
+
+[frontend/DESIGN_SYSTEM.md](frontend/DESIGN_SYSTEM.md) (in Chinese) is authoritative and worth reading before UI work. The load-bearing rules:
+
+- **No UI component library, by design.** ~34 hand-written primitives in `src/components/ui/`. Don't propose adding one (headless included). ECharts is fine — a chart renderer isn't a component library.
+- **Tokens only** — `var(--brand)`, `var(--surface-3)`, `var(--text-2)`, `var(--line)`; never hardcode colors. Semantic colors come from `@/plugins/colors.ts`.
+- **Theming** = `<html data-theme="dark|light">`. The pre-paint script in `index.html` duplicates the `2sui-theme` localStorage read in `store/modules/app.ts` — change one, change both.
+- **No global component registration**; always import explicitly.
+- **Never use native `<select>`** — use `<Select>` (it parses slot vnodes so bound values keep their type).
+- **Overlays must use `pushOverlay()`** from `components/ui/overlay.ts`; never hand-roll an Esc listener.
+- Drawers/modals live in `layouts/drawers/`, not `components/`. Forms split by direction under `components/forms/in|out/`.
+- After touching `components/ui/`, `npx vue-tsc --noEmit` must be 0 errors; `scripts/extract-component-api.mjs` regenerates the doc's prop tables.
+
+i18n keys are **structural, not just display**: route `name`s are i18n keys, and toasts are built as `t('actions.'+action) + ' ' + t('objects.'+obj)` — renaming a key silently breaks them. File names ≠ locale keys (`zhcn.ts` → `zhHans`, `zhtw.ts` → `zhHant`). `locales/ui/*.ts` are nominally generated, but the generator needs an external design-handoff dir that isn't in this repo — **treat them as source**.
+
+ESLint is deliberately loosened (`vue/no-mutating-props` is `shallowOnly` because the forms pattern is parent-passes-object/child-mutates-fields; `eqeqeq` off; several rules downgraded to `warn`). **A clean lint run still emits warnings — that's expected.**
+
+## Release quirks
+
+- `release.yml` and `windows.yml` trigger on **both** `push: main` and `release: published`, and have no `concurrency:` block — merging a PR then publishing a release runs the full 7-platform matrix **twice**. Only the `release` run uploads assets (the upload step is gated on `github.event_name == 'release'`).
+- **`config/version` is not in any workflow path filter** — a version-bump-only PR triggers no release build.
+- `docker.yml` has no push trigger, so **a Dockerfile change is ungated until a release is cut**.
+- `Dockerfile.frontend-artifact` expects a prebuilt `frontend_dist/` in the build context (CI builds the frontend once natively rather than five times under QEMU). It **fails from a bare checkout** — use `Dockerfile` locally.
+- `.dockerignore` has no `*.exe` or `.git` entry, while the repo root accumulates ignored multi-hundred-MB `sui*.exe` binaries — they land in the Docker build context.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "qrcode.vue": "^3.9.1",
         "vue": "^3.5.34",
         "vue-i18n": "^11.4.6",
-        "vue-router": "^5.0.7",
+        "vue-router": "^5.2.0",
         "vue3-persian-datetime-picker": "^1.2.2",
         "yaml": "^2.9.0"
       },
@@ -38,13 +38,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "8.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0-rc.5.tgz",
-      "integrity": "sha512-nFZPWz3FHIS7y6rMIVoa/WBwjdutfIaRJIBQjzn+t3RnecZoRNlGmGcyR2wb0T/IgSd50Kz/6dG8/LvMCRunjg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
+      "integrity": "sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^8.0.0-rc.5",
-        "@babel/types": "^8.0.0-rc.5",
+        "@babel/parser": "^8.0.0",
+        "@babel/types": "^8.0.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "@types/jsesc": "^2.5.0",
@@ -55,30 +55,30 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@babel/helper-string-parser": {
-      "version": "8.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0-rc.5.tgz",
-      "integrity": "sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz",
+      "integrity": "sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==",
       "license": "MIT",
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/generator/node_modules/@babel/helper-validator-identifier": {
-      "version": "8.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.0-rc.5.tgz",
-      "integrity": "sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz",
+      "integrity": "sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==",
       "license": "MIT",
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
       }
     },
     "node_modules/@babel/generator/node_modules/@babel/parser": {
-      "version": "8.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0-rc.5.tgz",
-      "integrity": "sha512-/Mfg83rK3+jsRbl4Vbd0jqxc6M1A1/WNFtgrowRM1unEsD3XcNnrBdMM0JWakd0/RN9lseQKwPduW1TiEwKOlQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.4.tgz",
+      "integrity": "sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^8.0.0-rc.5"
+        "@babel/types": "^8.0.4"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -88,13 +88,13 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@babel/types": {
-      "version": "8.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.0-rc.5.tgz",
-      "integrity": "sha512-JeSVu/m8x/zpp4CLjYHVNXuhEyOkhPXuxM8YOXjh6L4LlvQNKuUNOTo5KdBuKAcTDHw8DquToTaEkhsBqPXOaA==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-8.0.4.tgz",
+      "integrity": "sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^8.0.0-rc.5",
-        "@babel/helper-validator-identifier": "^8.0.0-rc.5"
+        "@babel/helper-string-parser": "^8.0.0",
+        "@babel/helper-validator-identifier": "^8.0.4"
       },
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
@@ -150,7 +150,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -162,7 +161,6 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -173,7 +171,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -502,7 +499,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -521,7 +517,7 @@
       "version": "0.139.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
       "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -534,7 +530,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -551,7 +546,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -568,7 +562,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -585,7 +578,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -602,7 +594,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -619,7 +610,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -639,7 +629,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -659,7 +648,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -679,7 +667,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -699,7 +686,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -719,7 +705,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -739,7 +724,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -756,7 +740,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -775,7 +758,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -792,7 +774,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -806,14 +787,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -851,7 +831,7 @@
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
       "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
@@ -1134,9 +1114,9 @@
       }
     },
     "node_modules/@vue-macros/common": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.2.tgz",
-      "integrity": "sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.3.tgz",
+      "integrity": "sha512-pphnexn8CDKugcA4TYSKlg1XanBYPbILST+eZK9ZGqG8sVbNR5L0kXEpRqs8+iSznosHt/Jo2k1FGl0tnWIpyg==",
       "license": "MIT",
       "dependencies": {
         "@vue/compiler-sfc": "^3.5.22",
@@ -1378,13 +1358,14 @@
       }
     },
     "node_modules/ast-walker-scope": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.8.3.tgz",
-      "integrity": "sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.9.0.tgz",
+      "integrity": "sha512-IJdzo2vLiElBxKzwS36VsCue/62d6IdWjnPB2v3nuPKeWGynp6FF/CYoLa5i/3jXH/z97ZDdsXz6abpgM6w07A==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.4",
-        "ast-kit": "^2.1.3"
+        "@babel/parser": "^7.29.2",
+        "@babel/types": "^7.29.0",
+        "ast-kit": "^2.2.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -1586,7 +1567,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -1886,9 +1867,9 @@
       }
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.0.tgz",
+      "integrity": "sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==",
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -2026,7 +2007,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2383,7 +2363,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -2416,7 +2396,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2437,7 +2416,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2458,7 +2436,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2479,7 +2456,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2500,7 +2476,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2521,7 +2496,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -2545,7 +2519,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -2569,7 +2542,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "glibc"
       ],
@@ -2593,7 +2565,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "libc": [
         "musl"
       ],
@@ -2617,7 +2588,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2638,7 +2608,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2653,9 +2622,9 @@
       }
     },
     "node_modules/local-pkg": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
-      "integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.2.1.tgz",
+      "integrity": "sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==",
       "license": "MIT",
       "dependencies": {
         "mlly": "^1.7.4",
@@ -3172,7 +3141,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
       "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.139.0",
@@ -3298,7 +3267,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD",
       "optional": true
     },
@@ -3363,31 +3331,71 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unplugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
-      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
+      "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@farmfe/core": "*",
+        "@rspack/core": "*",
+        "bun-types-no-globals": "*",
+        "esbuild": "*",
+        "rolldown": "*",
+        "rollup": "*",
+        "unloader": "*",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "@farmfe/core": {
+          "optional": true
+        },
+        "@rspack/core": {
+          "optional": true
+        },
+        "bun-types-no-globals": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "unloader": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/unplugin-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
-      "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.2.tgz",
+      "integrity": "sha512-xVToRh2CTmLk2HnEG7ac4rl1MJTT3RFkpS8B++/SnB0kXvuaavD+n3m/vrzyWQOdJNSZQACnbz01pnppbwV5BA==",
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -3417,7 +3425,7 @@
       "version": "8.1.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
@@ -3572,37 +3580,39 @@
       "license": "MIT"
     },
     "node_modules/vue-router": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.7.tgz",
-      "integrity": "sha512-dqfk8kvRbCutmCOCj/XLDqDEYxc1wBdAOGLuVy5M93ifYMsBd5fIjfaPN4tQAbxr5IprdBDIox1gr4wYyOx/SA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.2.0.tgz",
+      "integrity": "sha512-QAC5i0LEb1GLG0LXDQmHu8L7FX12j0KwU/JTKmLQUJMrn04gQdKP6Du+p0QwpHb3iy71vBlqnHQ8WAfOSAWhqw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/generator": "^8.0.0-rc.4",
-        "@vue-macros/common": "^3.1.1",
-        "@vue/devtools-api": "^8.1.1",
-        "ast-walker-scope": "^0.8.3",
+        "@babel/generator": "^8.0.0",
+        "@vue-macros/common": "^3.1.3",
+        "@vue/devtools-api": "^8.1.5",
+        "ast-walker-scope": "^0.9.0",
         "chokidar": "^5.0.0",
         "json5": "^2.2.3",
-        "local-pkg": "^1.1.2",
+        "local-pkg": "^1.2.1",
         "magic-string": "^0.30.21",
-        "mlly": "^1.8.0",
+        "mlly": "^1.8.2",
         "muggle-string": "^0.4.1",
+        "nostics": "^1.1.4",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.5",
         "scule": "^1.3.0",
-        "tinyglobby": "^0.2.15",
-        "unplugin": "^3.0.0",
-        "unplugin-utils": "^0.3.1",
-        "yaml": "^2.8.2"
+        "tinyglobby": "^0.2.17",
+        "unplugin": "^3.3.0",
+        "unplugin-utils": "^0.3.2",
+        "yaml": "^2.9.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/posva"
       },
       "peerDependencies": {
         "@pinia/colada": ">=0.21.2",
-        "@vue/compiler-sfc": "^3.5.34",
-        "pinia": "^3.0.4",
-        "vue": "^3.5.34"
+        "@vue/compiler-sfc": "^3.5.34 || ^4.0.0",
+        "pinia": "^3.0.4 || ^4.0.2",
+        "vite": "^7.3.0 || ^8.0.0",
+        "vue": "^3.5.34 || ^4.0.0"
       },
       "peerDependenciesMeta": {
         "@pinia/colada": {
@@ -3612,6 +3622,9 @@
           "optional": true
         },
         "pinia": {
+          "optional": true
+        },
+        "vite": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "qrcode.vue": "^3.9.1",
     "vue": "^3.5.34",
     "vue-i18n": "^11.4.6",
-    "vue-router": "^5.0.7",
+    "vue-router": "^5.2.0",
     "vue3-persian-datetime-picker": "^1.2.2",
     "yaml": "^2.9.0"
   },


### PR DESCRIPTION
## Problem

`main` is red. #36 (pinia 3.0.4 -> 4.0.2) broke **every path that runs `npm install`**:

```
npm error ERESOLVE could not resolve
While resolving: vue-router@5.0.7
Found: pinia@4.0.2
Could not resolve dependency:
  peerOptional pinia@"^3.0.4" from vue-router@5.0.7
```

`vue-router@5.0.7` declares `peerOptional pinia@^3.0.4`, which pinia 4 does not satisfy.

## Why CI did not catch it

`ci.yml` is the only workflow that uses **`npm ci`**, which installs the lockfile verbatim and never re-resolves the tree — so it never evaluates the peer range. Everything that actually produces a binary uses **`npm install`**, which does:

| Path | Command | Before this PR |
|---|---|---|
| `ci.yml` (PR gate) | `npm ci` | pass |
| `release.yml` | `npm install` | **ERESOLVE** |
| `windows.yml` | `npm install` | **ERESOLVE** |
| `Dockerfile` | `npm install` | **ERESOLVE** |
| `build.sh` | `npm i` | **ERESOLVE** |
| `windows/build-windows.ps1` | `npm install` | **ERESOLVE** |

## Fix

`vue-router@5.2.0` widens the peer range to `^3.0.4 || ^4.0.2`. The `^5.0.7` spec already allowed it; only the lockfile pinned 5.0.7.

## Verification

Run against the real failing tree (`0a5f05d`), not a stale checkout:

- `npm install`: **exit 1 -> exit 0** (ERESOLVE reproduced, then gone)
- installed: pinia 4.0.2 + vue-router 5.2.0 + nostics 1.1.4 + @vue/devtools-api 8.1.5
- `npm run build` (`vue-tsc --noEmit && vite build`): **exit 0**, no type errors
- bundle: 2031611 -> **2029465** bytes (smaller); `setupDevtoolsPlugin` / `defineDiagnostics` / `birpc` all tree-shaken to 0
- `npx eslint .`: exit 0 (41 warnings, 0 errors — expected per CLAUDE.md)
- dev-server smoke test: panel renders, **zero console errors**, theme action works end-to-end (`data-theme=dark` + localStorage + repaint)

## Also

Adds `CLAUDE.md` documenting the `npm ci` vs `npm install` split, since the PR gate structurally cannot catch this class of break.