### PR TITLE
fix(docs,frontend,install): unbreak the legacy-install path, tidy up frontend deps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Related: `vite.config.mts` gives assets **random filenames per build** (not cont
 
 ### Version & migrations
 
-`config/version` (currently **1.5.5**) is `//go:embed`ed — **not** injected via `-X` ldflags. Bumping a release means editing that file in-tree; the git tag and the embedded version can drift. `cmd/migration/` gates on the **2s-ui** version line, not upstream's (users' `dbVersion` tracks 2s-ui releases) — see the comment in `cmd/migration/main.go` before adding one.
+`config/version` is `//go:embed`ed — **not** injected via `-X` ldflags. Bumping a release means editing that file in-tree; the git tag and the embedded version can drift. `cmd/migration/` gates on the **2s-ui** version line, not upstream's (users' `dbVersion` tracks 2s-ui releases) — see the comment in `cmd/migration/main.go` before adding one.
 
 ### `sui` CLI
 

--- a/README.fa.md
+++ b/README.fa.md
@@ -70,10 +70,10 @@ bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/main/install.sh)
 
 ## نصب نسخه قدیمی
 
-**گام ۱:** برای نصب نسخه قدیمی موردنظرتان، نسخه را به انتهای دستور نصب اضافه کنید. برای مثال نسخه `1.0.0`:
+**گام ۱:** برای نصب نسخه قدیمی موردنظرتان، نسخه را به انتهای دستور نصب اضافه کنید. برای مثال نسخه `v1.5.5`:
 
 ```sh
-VERSION=1.0.0 && bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh) $VERSION
+VERSION=v1.5.5 && bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh) $VERSION
 ```
 
 ## نصب دستی

--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/main/install.sh)
 
 ## Install legacy Version
 
-**Step 1:** To install your desired legacy version, add the version to the end of the installation command. e.g., ver `1.0.0`:
+**Step 1:** To install your desired legacy version, add the version to the end of the installation command. e.g., ver `v1.5.5`:
 
 ```sh
-VERSION=1.0.0 && bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh) $VERSION
+VERSION=v1.5.5 && bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh) $VERSION
 ```
 
 ## Manual installation

--- a/README.ru.md
+++ b/README.ru.md
@@ -70,10 +70,10 @@ bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/main/install.sh)
 
 ## Установка устаревшей версии
 
-**Шаг 1:** Чтобы установить нужную устаревшую версию, добавьте версию в конец команды установки. Например, версия `1.0.0`:
+**Шаг 1:** Чтобы установить нужную устаревшую версию, добавьте версию в конец команды установки. Например, версия `v1.5.5`:
 
 ```sh
-VERSION=1.0.0 && bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh) $VERSION
+VERSION=v1.5.5 && bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh) $VERSION
 ```
 
 ## Ручная установка

--- a/README.vi.md
+++ b/README.vi.md
@@ -69,10 +69,10 @@ bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/main/install.sh)
 
 ## Cài đặt phiên bản cũ
 
-**Bước 1:** Để cài đặt phiên bản cũ mà bạn mong muốn, thêm số phiên bản vào cuối lệnh cài đặt. Ví dụ, phiên bản `1.0.0`:
+**Bước 1:** Để cài đặt phiên bản cũ mà bạn mong muốn, thêm số phiên bản vào cuối lệnh cài đặt. Ví dụ, phiên bản `v1.5.5`:
 
 ```sh
-VERSION=1.0.0 && bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh) $VERSION
+VERSION=v1.5.5 && bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh) $VERSION
 ```
 
 ## Cài đặt thủ công

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,10 +69,10 @@ bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/main/install.sh)
 
 ## 安装历史版本
 
-**步骤 1：** 如果要安装指定历史版本，请在安装命令末尾添加版本号。例如版本 `1.0.0`：
+**步骤 1：** 如果要安装指定历史版本，请在安装命令末尾添加版本号。例如版本 `v1.5.5`：
 
 ```sh
-VERSION=1.0.0 && bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh) $VERSION
+VERSION=v1.5.5 && bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh) $VERSION
 ```
 
 ## 手动安装

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -72,10 +72,10 @@ bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/main/install.sh)
 
 ## 安裝歷史版本
 
-**步驟 1：** 如果要安裝指定歷史版本，請在安裝指令末尾加上版本號。例如版本 `1.0.0`：
+**步驟 1：** 如果要安裝指定歷史版本，請在安裝指令末尾加上版本號。例如版本 `v1.5.5`：
 
 ```sh
-VERSION=1.0.0 && bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh) $VERSION
+VERSION=v1.5.5 && bash <(curl -Ls https://raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh) $VERSION
 ```
 
 ## 手動安裝

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1983,16 +1983,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -2188,9 +2188,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "@eslint/js": "^10.0.1",
         "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.8",
+        "@vue/devtools-api": "^8.1.5",
         "eslint": "^10.7.0",
         "eslint-plugin-vue": "^10.9.1",
         "globals": "^17.7.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fontsource/jetbrains-mono": "^5.2.8",
         "@fontsource/manrope": "^5.2.8",
+        "@vue/devtools-api": "^8.1.5",
         "axios": "^1.18.1",
         "clipboard": "^2.0.11",
         "core-js": "^3.49.0",
@@ -28,7 +29,6 @@
         "@eslint/js": "^10.0.1",
         "@types/node": "^26.1.1",
         "@vitejs/plugin-vue": "^6.0.8",
-        "@vue/devtools-api": "^8.1.5",
         "eslint": "^10.7.0",
         "eslint-plugin-vue": "^10.9.1",
         "globals": "^17.7.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@fontsource/jetbrains-mono": "^5.2.8",
     "@fontsource/manrope": "^5.2.8",
+    "@vue/devtools-api": "^8.1.5",
     "axios": "^1.18.1",
     "clipboard": "^2.0.11",
     "core-js": "^3.49.0",
@@ -29,7 +30,6 @@
     "@eslint/js": "^10.0.1",
     "@types/node": "^26.1.1",
     "@vitejs/plugin-vue": "^6.0.8",
-    "@vue/devtools-api": "^8.1.5",
     "eslint": "^10.7.0",
     "eslint-plugin-vue": "^10.9.1",
     "globals": "^17.7.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "@eslint/js": "^10.0.1",
     "@types/node": "^26.1.1",
     "@vitejs/plugin-vue": "^6.0.8",
+    "@vue/devtools-api": "^8.1.5",
     "eslint": "^10.7.0",
     "eslint-plugin-vue": "^10.9.1",
     "globals": "^17.7.0",

--- a/install.sh
+++ b/install.sh
@@ -135,27 +135,31 @@ install_s-ui() {
     cd /tmp/
 
     if [ $# == 0 ]; then
-        last_version=$(curl -Ls "https://api.github.com/repos/shenaba/2s-ui/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-        if [[ ! -n "$last_version" ]]; then
+        tag=$(curl -Ls "https://api.github.com/repos/shenaba/2s-ui/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+        if [[ ! -n "$tag" ]]; then
             echo -e "${red}Failed to fetch s-ui version, it maybe due to Github API restrictions, please try it later${plain}"
             exit 1
         fi
-        echo -e "Got s-ui latest version: ${last_version}, beginning the installation..."
-        wget -N --no-check-certificate -O /tmp/s-ui-linux-$(arch).tar.gz https://github.com/shenaba/2s-ui/releases/download/${last_version}/s-ui-linux-$(arch).tar.gz
+        echo -e "Got s-ui latest version: ${tag}, beginning the installation..."
+        wget -N --no-check-certificate -O /tmp/s-ui-linux-$(arch).tar.gz https://github.com/shenaba/2s-ui/releases/download/${tag}/s-ui-linux-$(arch).tar.gz
         if [[ $? -ne 0 ]]; then
             echo -e "${red}Downloading s-ui failed, please be sure that your server can access Github ${plain}"
             exit 1
         fi
     else
-        last_version=$1
-        url="https://github.com/shenaba/2s-ui/releases/download/${last_version}/s-ui-linux-$(arch).tar.gz"
-        echo -e "Beginning the install s-ui v$1"
+        # Every release tag is v-prefixed, so accept the argument with or without it.
+        tag="v${1#v}"
+        url="https://github.com/shenaba/2s-ui/releases/download/${tag}/s-ui-linux-$(arch).tar.gz"
+        echo -e "Beginning the install s-ui ${tag}"
         wget -N --no-check-certificate -O /tmp/s-ui-linux-$(arch).tar.gz ${url}
         if [[ $? -ne 0 ]]; then
-            echo -e "${red}download s-ui v$1 failed,please check the version exists${plain}"
+            echo -e "${red}download s-ui ${tag} failed, please check the version exists${plain}"
             exit 1
         fi
     fi
+
+    # ${tag} keeps the v prefix for URLs; ${last_version} is bare for display.
+    last_version="${tag#v}"
 
     if [[ -e /usr/local/s-ui/ ]]; then
         systemctl stop s-ui


### PR DESCRIPTION
Papercuts left over from the pinia 4 bump, plus two things found while verifying them. Split by concern below.

## 1. README legacy-install example 404s (all six locales)

The snippet used `VERSION=1.0.0`. Two separate things are wrong with it: there is no `v` prefix, and **there has never been a `1.0.0` tag in this repo** — the earliest tag is `v1.4.0`.

`install.sh` interpolates the argument **verbatim** into the download URL, and the README also puts it in the `raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh` ref. Every tag here is `vX.Y.Z`, so **both URLs 404** and the documented command cannot work. Verified:

| URL | Status |
|---|---|
| `raw.githubusercontent.com/.../v1.5.5/install.sh` | **200** |
| `releases/download/v1.5.5/s-ui-linux-amd64.tar.gz` | **200** |
| `raw.githubusercontent.com/.../1.5.5/install.sh` | **404** |
| `releases/download/1.0.0/s-ui-linux-amd64.tar.gz` | **404** |

The example now uses a real, working tag. Only the version string changed — the prose in each locale is untouched (2 lines per file, 12 total).

## 2. `install.sh` has always printed `s-ui vv1.5.5`

Found while checking what §1 actually does at runtime. `install_s-ui` stored two different things in `$last_version` depending on which path ran:

| path | what `$last_version` held |
|---|---|
| no-arg | `tag_name` from the GitHub API — **v-prefixed** |
| argument | `$1`, verbatim |

Both download URLs need the prefix, but every `echo` hardcodes its own `v` (`echo "s-ui v${last_version}"`). So the **no-arg path — the one every install doc uses — has always printed `s-ui vv1.5.5`** on success. §1 pointing the example at a real (`v`-prefixed) tag would have spread the same double prefix to two more lines, which is what surfaced it.

Rather than paper over either side, this splits the two meanings: **`$tag`** keeps the prefix and builds the URL, **`$last_version`** is bare and feeds the display. The argument path normalises with `${1#v}`, so `1.5.5` and `v1.5.5` both resolve.

That normalisation is **only** a convenience for callers that already have the script — it does not make §1 optional. The README must still pass the prefix, because `$VERSION` is also the `raw.githubusercontent.com` ref that fetches `install.sh` in the first place, and script-side normalisation cannot rescue a 404 that happens before the script exists.

## 3. `@vue/devtools-api` was undeclared

pinia 4 moved it from a `dependency` to a **required** peer (`peerDependenciesMeta: { "@vue/devtools-api": { "optional": false } }`), and [its changelog](https://github.com/vuejs/pinia/blob/v4.0.2/packages/pinia/CHANGELOG.md) asks consumers to install it themselves.

We satisfy that peer **by coincidence**: `vue-router@5.2.0` lists `@vue/devtools-api: ^8.1.5` in its own regular `dependencies` (not as a peer), so npm hoists it to the root and pinia's peer resolves against that copy. Nothing at the root ever asked for it.

Declared as a **`dependency`**: pinia is a runtime dependency, so its non-optional peer belongs in the same field. (`vite` / `vue-tsc` are tools we *invoke* — they never enter the source module graph. `@vue/devtools-api` is imported statically by pinia's dist and is only absent from the output because the bundler proves the `NODE_ENV`-guarded branches dead. "Tree-shaken out of the bundle" is not the same claim as "devDependency".)

### This one is inert today, on purpose

It changes **nothing** about resolution — the package is already a hard transitive dependency via vue-router, so the lockfile's package entry is untouched and only the root declaration is added. It documents an existing constraint; it does not fix a broken tree. The value is narrow but real: if vue-router ever drops the dependency, we would fall back to npm's auto-peer-install instead of a range we own.

## 4. `form-data` advisory — hygiene, not a security fix

`npm audit` flagged form-data 4.0.5 high ([GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx), CRLF injection). It reaches us only through axios, and axios already permits the fix — its range is `^4.0.5`, so 4.0.6 needs no `package.json` change.

**It was never exploitable here, because form-data never shipped:**

```js
// axios/lib/platform/node/classes/FormData.js     -> tree-shaken out
import FormData from 'form-data';
// axios/lib/platform/browser/classes/FormData.js  -> what actually builds
export default typeof FormData !== 'undefined' ? FormData : null;
```

The browser build uses the native `FormData`. The only `form-data` strings left in the bundle are the `multipart/form-data` MIME type. The bundle is unchanged at 2029465 bytes — which is exactly what proves the package was never in it.

Bumped anyway for signal-to-noise: `npm audit` is now clean, so the next finding will not be lost behind a permanent false positive.

## 5. `CLAUDE.md` pinned a version it warns will drift

The Version & migrations section read ``config/version`` *(currently **1.5.5**)* — one clause before "the git tag and the embedded version can drift". It had duly drifted: `config/version` reads `1.5.6-alpha.1`.

Dropped rather than re-pinned; the number carries nothing a `cat config/version` would not, and re-pinning just resets the clock to the next release. The Go `1.26.4` reference is left alone — it still matches `go.mod`, and its actual point is the contradiction with `CONTRIBUTING.md`.

## Verification

- `npm install --package-lock-only`: exit 0 (the re-resolving path that `npm ci` hides — see CLAUDE.md), lockfile stable
- `npm ci`: exit 0 (lockfile and `package.json` agree)
- `npm run build` (`vue-tsc --noEmit && vite build`): exit 0
- `npm audit`: 0 vulnerabilities (was 1 high)
- bundle **byte-identical at 2029465** across every change here — none of them was ever in it
- `setupDevtoolsPlugin` / `defineDiagnostics` / `createConsoleReporter` / `birpc` / `devtools-kit`: 0 occurrences in the bundle
- `bash -n install.sh`: clean. Normalisation exercised across every input shape, each resulting URL fetched for real:

| arg | tag built | asset |
|---|---|---|
| `1.5.5` | `v1.5.5` | **200** |
| `v1.5.5` | `v1.5.5` | **200** |
| `1.5.6-alpha.1` | `v1.5.6-alpha.1` | **200** |

  Display on both paths is now `s-ui v1.5.5` (was `s-ui vv1.5.5` on the no-arg path).

**`install.sh` was not executed end-to-end** — it installs a systemd unit, so it is not runnable here. The changed region is the version/URL handling that sits entirely above the first side effect.
