### PR TITLE
fix(install,docs): normalise the version prefix, drop the drifted CLAUDE.md pin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Related: `vite.config.mts` gives assets **random filenames per build** (not cont
 
 ### Version & migrations
 
-`config/version` (currently **1.5.5**) is `//go:embed`ed — **not** injected via `-X` ldflags. Bumping a release means editing that file in-tree; the git tag and the embedded version can drift. `cmd/migration/` gates on the **2s-ui** version line, not upstream's (users' `dbVersion` tracks 2s-ui releases) — see the comment in `cmd/migration/main.go` before adding one.
+`config/version` is `//go:embed`ed — **not** injected via `-X` ldflags. Bumping a release means editing that file in-tree; the git tag and the embedded version can drift. `cmd/migration/` gates on the **2s-ui** version line, not upstream's (users' `dbVersion` tracks 2s-ui releases) — see the comment in `cmd/migration/main.go` before adding one.
 
 ### `sui` CLI
 

--- a/install.sh
+++ b/install.sh
@@ -135,27 +135,31 @@ install_s-ui() {
     cd /tmp/
 
     if [ $# == 0 ]; then
-        last_version=$(curl -Ls "https://api.github.com/repos/shenaba/2s-ui/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-        if [[ ! -n "$last_version" ]]; then
+        tag=$(curl -Ls "https://api.github.com/repos/shenaba/2s-ui/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+        if [[ ! -n "$tag" ]]; then
             echo -e "${red}Failed to fetch s-ui version, it maybe due to Github API restrictions, please try it later${plain}"
             exit 1
         fi
-        echo -e "Got s-ui latest version: ${last_version}, beginning the installation..."
-        wget -N --no-check-certificate -O /tmp/s-ui-linux-$(arch).tar.gz https://github.com/shenaba/2s-ui/releases/download/${last_version}/s-ui-linux-$(arch).tar.gz
+        echo -e "Got s-ui latest version: ${tag}, beginning the installation..."
+        wget -N --no-check-certificate -O /tmp/s-ui-linux-$(arch).tar.gz https://github.com/shenaba/2s-ui/releases/download/${tag}/s-ui-linux-$(arch).tar.gz
         if [[ $? -ne 0 ]]; then
             echo -e "${red}Downloading s-ui failed, please be sure that your server can access Github ${plain}"
             exit 1
         fi
     else
-        last_version=$1
-        url="https://github.com/shenaba/2s-ui/releases/download/${last_version}/s-ui-linux-$(arch).tar.gz"
-        echo -e "Beginning the install s-ui v$1"
+        # Every release tag is v-prefixed, so accept the argument with or without it.
+        tag="v${1#v}"
+        url="https://github.com/shenaba/2s-ui/releases/download/${tag}/s-ui-linux-$(arch).tar.gz"
+        echo -e "Beginning the install s-ui ${tag}"
         wget -N --no-check-certificate -O /tmp/s-ui-linux-$(arch).tar.gz ${url}
         if [[ $? -ne 0 ]]; then
-            echo -e "${red}download s-ui v$1 failed,please check the version exists${plain}"
+            echo -e "${red}download s-ui ${tag} failed, please check the version exists${plain}"
             exit 1
         fi
     fi
+
+    # ${tag} keeps the v prefix for URLs; ${last_version} is bare for display.
+    last_version="${tag#v}"
 
     if [[ -e /usr/local/s-ui/ ]]; then
         systemctl stop s-ui


### PR DESCRIPTION
Two follow-ups split out of #41, which deliberately left both alone rather than scope-creep a docs PR. Unrelated to each other; happy to split further if preferred.

## 1. `install.sh` has always printed `s-ui vv1.5.5`

`install_s-ui` stored two different things in `$last_version` depending on which path ran:

| path | what `$last_version` held |
|---|---|
| no-arg | `tag_name` from the GitHub API — **v-prefixed** |
| argument | `$1`, verbatim |

Both download URLs need the prefix, but every `echo` hardcodes its own `v` (`echo "s-ui v${last_version}"`). So the **no-arg path — the one every install doc uses — has always printed `s-ui vv1.5.5`** on success. #41 pointing the legacy example at a real (`v`-prefixed) tag spread the same double prefix to two more lines, which is what surfaced this.

Rather than paper over either side, this splits the two meanings:

- **`$tag`** — keeps the prefix, builds the URL
- **`$last_version`** — bare, feeds the display

The argument path normalises with `${1#v}`, so `1.5.5` and `v1.5.5` both resolve.

That last bit is **only** a convenience for callers that already have the script. **The README still has to pass the prefix**, because it also interpolates `$VERSION` as the `raw.githubusercontent.com/shenaba/2s-ui/$VERSION/install.sh` ref that fetches the script in the first place — script-side normalisation cannot rescue a 404 that happens before the script exists. #41 is still required.

### Verification

- `bash -n install.sh`: clean
- Normalisation exercised across every input shape, and each resulting URL fetched for real:

| arg | tag built | asset |
|---|---|---|
| `1.5.5` | `v1.5.5` | **200** |
| `v1.5.5` | `v1.5.5` | **200** |
| `1.5.6-alpha.1` | `v1.5.6-alpha.1` | **200** |

- Display output on both paths is now `s-ui v1.5.5` (was `s-ui vv1.5.5` on the no-arg path).

**Not executed end-to-end** — the script installs a systemd unit, so it is not runnable here. The changed region is the version/URL handling that sits entirely above the first side effect.

## 2. `CLAUDE.md` pinned a version it warns will drift

The Version & migrations section read ``config/version`` *(currently **1.5.5**)* — one clause before "the git tag and the embedded version can drift". It had duly drifted: `config/version` reads `1.5.6-alpha.1`.

Dropped rather than re-pinned; the number carries nothing a `cat config/version` would not, and re-pinning just resets the clock to the next release.

The Go `1.26.4` reference is left alone on purpose — it still matches `go.mod`, and its actual point is the contradiction with `CONTRIBUTING.md`.
