### PR TITLE
Port upstream v1.5.4 bug fixes

### DIFF
--- a/database/model/outbounds.go
+++ b/database/model/outbounds.go
@@ -49,5 +49,14 @@ func (o Outbound) MarshalJSON() ([]byte, error) {
 		}
 	}
 
+	if tlsRaw, ok := combined["tls"].(json.RawMessage); ok {
+		var tlsObj map[string]interface{}
+		if json.Unmarshal(tlsRaw, &tlsObj) == nil {
+			if enabled, _ := tlsObj["enabled"].(bool); !enabled {
+				delete(combined, "tls")
+			}
+		}
+	}
+
 	return json.Marshal(combined)
 }

--- a/frontend/src/components/forms/in/OutJson.vue
+++ b/frontend/src/components/forms/in/OutJson.vue
@@ -47,6 +47,14 @@
         <input class="input mono" type="number" min="0" v-model.number="hop_interval" />
       </Field>
     </template>
+    <template v-if="type == inTypes.Shadowsocks">
+      <Field label="Plugin">
+        <input class="input mono" v-model="plugin" />
+      </Field>
+      <Field v-if="inData.out_json.plugin" label="Plugin Options">
+        <input class="input mono" v-model="pluginOpts" />
+      </Field>
+    </template>
     <Headers v-if="type == inTypes.HTTP" :data="inData.out_json" />
     <AnyTls v-if="type == inTypes.AnyTls" :data="inData.out_json" direction="out_json" />
     <Naive v-if="type == inTypes.Naive" :data="inData.out_json" direction="out_json" />
@@ -133,5 +141,20 @@ const hop_interval = computed({
   get: (): number =>
     props.inData.out_json.hop_interval ? parseInt(props.inData.out_json.hop_interval.replace('s', '')) : 0,
   set: (v: number) => { props.inData.out_json.hop_interval = v > 0 ? v + 's' : undefined },
+})
+
+// These two ride in out_json rather than the inbound itself: sing-box has no
+// server-side plugin option, but the client needs `?plugin=` in its ss:// link.
+const plugin = computed({
+  get: (): string => props.inData.out_json.plugin ?? '',
+  set: (v: string) => {
+    props.inData.out_json.plugin = v.length > 0 ? v : undefined
+    if (!props.inData.out_json.plugin) props.inData.out_json.plugin_opts = undefined
+  },
+})
+
+const pluginOpts = computed({
+  get: (): string => props.inData.out_json.plugin_opts ?? '',
+  set: (v: string) => { props.inData.out_json.plugin_opts = v.length > 0 ? v : undefined },
 })
 </script>

--- a/frontend/src/components/forms/out/protocols/Shadowsocks.vue
+++ b/frontend/src/components/forms/out/protocols/Shadowsocks.vue
@@ -11,15 +11,38 @@
   <Field :label="$t('types.pw')">
     <input class="input mono" v-model="data.password" />
   </Field>
+  <div class="grid2">
+    <Field label="Plugin" :mb="0">
+      <input class="input mono" v-model="plugin" />
+    </Field>
+    <Field v-if="data.plugin" label="Plugin Options" :mb="0">
+      <input class="input mono" v-model="pluginOpts" />
+    </Field>
+  </div>
 </template>
 
 <script lang="ts" setup>
+import { computed } from 'vue'
 import Select from '@/components/ui/Select.vue'
 import Field from '@/components/ui/Field.vue'
 import Network from '../Network.vue'
 import UoT from '../UoT.vue'
 
-defineProps<{ data: any }>()
+const props = defineProps<{ data: any }>()
+
+// Empty strings must collapse to undefined: the value is spread straight into
+// the sing-box outbound JSON, and an empty `plugin` key is not the same as none.
+const plugin = computed({
+  get: (): string => props.data.plugin ?? '',
+  set: (v: string) => {
+    props.data.plugin = v.length > 0 ? v : undefined
+    if (!props.data.plugin) props.data.plugin_opts = undefined
+  },
+})
+const pluginOpts = computed({
+  get: (): string => props.data.plugin_opts ?? '',
+  set: (v: string) => { props.data.plugin_opts = v.length > 0 ? v : undefined },
+})
 
 const ssMethods = [
   'none',

--- a/frontend/src/types/outbounds.ts
+++ b/frontend/src/types/outbounds.ts
@@ -78,6 +78,8 @@ export interface Shadowsocks extends OutboundBasics, Dial {
     version?: number
   }
   multiplex?: oMultiplex
+  plugin?: string
+  plugin_opts?: string
 }
 
 export interface VMESS extends OutboundBasics, Dial {

--- a/sub/clashService.go
+++ b/sub/clashService.go
@@ -320,6 +320,11 @@ func (s *ClashService) ConvertToClashMeta(outbounds *[]map[string]interface{}, b
 				if len(wsHeaders) > 0 {
 					wsOpts["headers"] = wsHeaders
 				}
+				// mihomo needs both keys before it will use early data: the
+				// header name alone leaves max-early-data at 0, which disables it.
+				if maxED, ok := transport["max_early_data"].(float64); ok && maxED > 0 {
+					wsOpts["max-early-data"] = int(maxED)
+				}
 				if ed, ok := transport["early_data_header_name"].(string); ok {
 					wsOpts["early-data-header-name"] = ed
 				}
@@ -406,10 +411,9 @@ func (s *ClashService) ConvertToClashMeta(outbounds *[]map[string]interface{}, b
 
 func buildProxyGroups(output map[string]interface{}, proxyTags []string, noDefGrp bool, sprtAll bool) error {
 	customGroups := proxyGroupList(output["proxy-groups"])
-	proxyGroups := mergeProxyGroups(nil, customGroups)
+	var defaultGroups []map[string]interface{}
 
 	if !noDefGrp {
-		var defaultGroups []map[string]interface{}
 		if err := yaml.Unmarshal([]byte(ProxyGroups), &defaultGroups); err != nil {
 			return err
 		}
@@ -420,8 +424,9 @@ func buildProxyGroups(output map[string]interface{}, proxyTags []string, noDefGr
 			defaultGroups = defaultGroups[:1]
 			defaultGroups[0]["proxies"] = proxyTags
 		}
-		proxyGroups = mergeProxyGroups(defaultGroups, customGroups)
 	}
+	// noDefGrp leaves defaultGroups nil, so this is the custom groups alone.
+	proxyGroups := mergeProxyGroups(defaultGroups, customGroups)
 
 	if len(proxyGroups) > 0 || !noDefGrp {
 		resolveProxyGroupTags(proxyGroups, proxyTags, sprtAll)
@@ -450,7 +455,13 @@ func mergeProxyGroups(base, extra []map[string]interface{}) []map[string]interfa
 	groups := make([]map[string]interface{}, 0, len(base)+len(extra))
 	index := make(map[string]int)
 
-	for _, group := range append(base, extra...) {
+	// Not append(base, extra...): that writes into base's backing array when it
+	// has spare capacity, which base[:1] above deliberately leaves.
+	all := make([]map[string]interface{}, 0, len(base)+len(extra))
+	all = append(all, base...)
+	all = append(all, extra...)
+
+	for _, group := range all {
 		if gname, ok := group["name"].(string); ok {
 			if i, exists := index[gname]; exists {
 				mergeProxyGroup(groups[i], group)

--- a/sub/clashService.go
+++ b/sub/clashService.go
@@ -1,6 +1,7 @@
 package sub
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/shenaba/2s-ui/logger"
@@ -295,14 +296,15 @@ func (s *ClashService) ConvertToClashMeta(outbounds *[]map[string]interface{}, b
 					wsOpts["path"] = path
 				}
 				wsHeaders := make(map[string]interface{})
+				// Only the Host header is carried into Clash
 				if headers, ok := transport["headers"].(map[string]interface{}); ok {
-					for k, v := range headers {
+					if v, ok := headers["Host"]; ok {
 						if arr, ok := v.([]interface{}); ok {
 							if len(arr) > 0 {
-								wsHeaders[k] = arr[0]
+								wsHeaders["Host"] = arr[0]
 							}
 						} else {
-							wsHeaders[k] = v
+							wsHeaders["Host"] = v
 						}
 					}
 				}
@@ -389,65 +391,10 @@ func (s *ClashService) ConvertToClashMeta(outbounds *[]map[string]interface{}, b
 		output["proxies"] = proxies
 	}
 
-	pgSlice, _ := output["proxy-groups"].([]interface{})
-
 	noDefGrp, _ := s.SettingService.GetSubClashNoDefGrp()
 	sprtAll, _ := s.SettingService.GetSubClashSprtAll()
-
-	if !noDefGrp {
-		var proxyGroups []map[string]interface{}
-		if err := yaml.Unmarshal([]byte(ProxyGroups), &proxyGroups); err != nil {
-			return "", err
-		}
-		proxyGroups[1]["proxies"] = proxyTags
-		proxyGroups[0]["proxies"] = append([]string{proxyGroups[1]["name"].(string)}, proxyTags...)
-		// Don't inject a duplicate "Auto" if the user already defines one.
-		if hasGroupNamed(pgSlice, "Auto") {
-			proxyGroups = proxyGroups[:1]
-			proxyGroups[0]["proxies"] = proxyTags
-		}
-		if pg, ok := output["proxy-groups"].([]interface{}); ok {
-			for _, item := range pg {
-				if g, ok := item.(map[string]interface{}); ok {
-					proxyGroups = append(proxyGroups, g)
-				}
-			}
-			output["proxy-groups"] = proxyGroups
-		} else {
-			output["proxy-groups"] = proxyGroups
-		}
-	}
-
-	if sprtAll {
-		expand := func(group map[string]interface{}) {
-			proxies, ok := group["proxies"].([]interface{})
-			if !ok {
-				return
-			}
-			newProxies := make([]interface{}, 0, len(proxies))
-			for _, p := range proxies {
-				if name, ok := p.(string); ok && strings.EqualFold(name, "all") {
-					for _, tag := range proxyTags {
-						newProxies = append(newProxies, tag)
-					}
-				} else {
-					newProxies = append(newProxies, p)
-				}
-			}
-			group["proxies"] = newProxies
-		}
-		switch list := output["proxy-groups"].(type) {
-		case []map[string]interface{}: // after default-group injection
-			for _, group := range list {
-				expand(group)
-			}
-		case []interface{}: // noDefGrp: groups come straight from the user's YAML
-			for _, item := range list {
-				if group, ok := item.(map[string]interface{}); ok {
-					expand(group)
-				}
-			}
-		}
+	if err := buildProxyGroups(output, proxyTags, noDefGrp, sprtAll); err != nil {
+		return "", err
 	}
 
 	result, err := yaml.Marshal(output)
@@ -457,17 +404,153 @@ func (s *ClashService) ConvertToClashMeta(outbounds *[]map[string]interface{}, b
 	return string(result), nil
 }
 
-// hasGroupNamed checks whether a "proxy-groups" interface{} slice contains a group with the given name.
-func hasGroupNamed(pg interface{}, name string) bool {
-	list, ok := pg.([]interface{})
-	if !ok {
-		return false
+func buildProxyGroups(output map[string]interface{}, proxyTags []string, noDefGrp bool, sprtAll bool) error {
+	customGroups := proxyGroupList(output["proxy-groups"])
+	proxyGroups := mergeProxyGroups(nil, customGroups)
+
+	if !noDefGrp {
+		var defaultGroups []map[string]interface{}
+		if err := yaml.Unmarshal([]byte(ProxyGroups), &defaultGroups); err != nil {
+			return err
+		}
+		defaultGroups[1]["proxies"] = proxyTags
+		defaultGroups[0]["proxies"] = append([]string{defaultGroups[1]["name"].(string)}, proxyTags...)
+		// Don't inject a duplicate "Auto" if the user already defines one.
+		if hasGroupNamed(customGroups, "Auto") {
+			defaultGroups = defaultGroups[:1]
+			defaultGroups[0]["proxies"] = proxyTags
+		}
+		proxyGroups = mergeProxyGroups(defaultGroups, customGroups)
 	}
-	for _, item := range list {
-		group, ok := item.(map[string]interface{})
-		if !ok {
+
+	if len(proxyGroups) > 0 || !noDefGrp {
+		resolveProxyGroupTags(proxyGroups, proxyTags, sprtAll)
+		output["proxy-groups"] = proxyGroups
+	}
+	return nil
+}
+
+func proxyGroupList(pg interface{}) []map[string]interface{} {
+	switch list := pg.(type) {
+	case []map[string]interface{}:
+		return list
+	case []interface{}:
+		groups := make([]map[string]interface{}, 0, len(list))
+		for _, item := range list {
+			if group, ok := item.(map[string]interface{}); ok {
+				groups = append(groups, group)
+			}
+		}
+		return groups
+	}
+	return nil
+}
+
+func mergeProxyGroups(base, extra []map[string]interface{}) []map[string]interface{} {
+	groups := make([]map[string]interface{}, 0, len(base)+len(extra))
+	index := make(map[string]int)
+
+	for _, group := range append(base, extra...) {
+		if gname, ok := group["name"].(string); ok {
+			if i, exists := index[gname]; exists {
+				mergeProxyGroup(groups[i], group)
+				continue
+			}
+			index[gname] = len(groups)
+		}
+		groups = append(groups, group)
+	}
+	return groups
+}
+
+func mergeProxyGroup(dst, src map[string]interface{}) {
+	for key, value := range src {
+		switch key {
+		case "name":
+			continue
+		case "proxies":
+			dst["proxies"] = appendProxyNames(proxyNames(dst["proxies"]), proxyNames(value))
+		default:
+			if _, exists := dst[key]; !exists {
+				dst[key] = value
+			}
+		}
+	}
+}
+
+func resolveProxyGroupTags(groups []map[string]interface{}, proxyTags []string, sprtAll bool) {
+	for _, group := range groups {
+		proxies := proxyNames(group["proxies"])
+		if sprtAll {
+			proxies = expandAllProxyTag(proxies, proxyTags)
+		}
+		if filter, _ := group["filter"].(string); filter != "" {
+			proxies = appendProxyNames(proxies, filteredProxyTags(proxyTags, filter))
+		}
+		if len(proxies) > 0 {
+			group["proxies"] = proxies
+		}
+	}
+}
+
+func expandAllProxyTag(proxies []string, proxyTags []string) []string {
+	result := make([]string, 0, len(proxies)+len(proxyTags))
+	for _, proxy := range proxies {
+		if strings.EqualFold(proxy, "all") {
+			result = appendProxyNames(result, proxyTags)
+		} else {
+			result = appendProxyNames(result, []string{proxy})
+		}
+	}
+	return result
+}
+
+func filteredProxyTags(proxyTags []string, filter string) []string {
+	re, err := regexp.Compile(filter)
+	if err != nil {
+		logger.Warning("sub: invalid Clash proxy-group filter:", err)
+		return nil
+	}
+	var result []string
+	for _, tag := range proxyTags {
+		if re.MatchString(tag) {
+			result = append(result, tag)
+		}
+	}
+	return result
+}
+
+func proxyNames(value interface{}) []string {
+	switch list := value.(type) {
+	case []string:
+		return append([]string(nil), list...)
+	case []interface{}:
+		proxies := make([]string, 0, len(list))
+		for _, item := range list {
+			if name, ok := item.(string); ok {
+				proxies = append(proxies, name)
+			}
+		}
+		return proxies
+	}
+	return nil
+}
+
+func appendProxyNames(proxies []string, names []string) []string {
+	seen := make(map[string]bool, len(proxies)+len(names))
+	result := make([]string, 0, len(proxies)+len(names))
+	for _, name := range append(proxies, names...) {
+		if name == "" || seen[name] {
 			continue
 		}
+		seen[name] = true
+		result = append(result, name)
+	}
+	return result
+}
+
+func hasGroupNamed(groups []map[string]interface{}, name string) bool {
+	for _, group := range groups {
 		if gname, ok := group["name"].(string); ok && gname == name {
 			return true
 		}

--- a/util/genLink.go
+++ b/util/genLink.go
@@ -589,6 +589,15 @@ func getTransportParams(t interface{}) []LinkParam {
 		}
 	case "ws":
 		if path, ok := trasport["path"].(string); ok {
+			if maxED, ok := trasport["max_early_data"].(float64); ok && maxED > 0 {
+				if edName, _ := trasport["early_data_header_name"].(string); edName == "Sec-WebSocket-Protocol" {
+					sep := "?"
+					if strings.Contains(path, "?") {
+						sep = "&"
+					}
+					path = fmt.Sprintf("%s%sed=%d", path, sep, int(maxED))
+				}
+			}
 			params = append(params, LinkParam{"path", path})
 		}
 		if headers, ok := trasport["headers"].(map[string]interface{}); ok {

--- a/util/genLink.go
+++ b/util/genLink.go
@@ -187,10 +187,28 @@ func shadowsocksLink(
 
 	uriBase := fmt.Sprintf("ss://%s", toBase64([]byte(fmt.Sprintf("%s:%s", method, strings.Join(userPass, ":")))))
 
+	var plugin, pluginOpts string
+	if raw, ok := inbound["out_json"].(json.RawMessage); ok {
+		var outJson map[string]interface{}
+		if json.Unmarshal(raw, &outJson) == nil {
+			plugin, _ = outJson["plugin"].(string)
+			pluginOpts, _ = outJson["plugin_opts"].(string)
+		}
+	}
+
 	var links []string
 	for _, addr := range addrs {
 		port, _ := addr["server_port"].(float64)
-		links = append(links, fmt.Sprintf("%s@%s:%.0f#%s", uriBase, addr["server"].(string), port, addr["remark"].(string)))
+		link := fmt.Sprintf("%s@%s:%.0f", uriBase, addr["server"].(string), port)
+		if plugin != "" {
+			pluginVal := plugin
+			if pluginOpts != "" {
+				pluginVal += ";" + pluginOpts
+			}
+			link += "?plugin=" + url.QueryEscape(pluginVal)
+		}
+		link += "#" + addr["remark"].(string)
+		links = append(links, link)
 	}
 	return links
 }


### PR DESCRIPTION
Ports the low-risk fixes from upstream v1.5.4 (`alireza0/s-ui`). Each commit names the upstream sha it came from.

## What is fixed

**Clash subscriptions** (`99e9d65`, `88b6743`)
- A user-defined proxy group sharing a name with a default group was appended alongside it, and mihomo rejects the whole config on a duplicate name. Groups now merge by name. Also adds proxy-group `filter` (a regexp over proxy tags).
- `ws-opts.headers` copied *every* transport header from the inbound to the client. An inbound's `headers` are the response headers sing-box sends — only `Host` means anything to the client, so only `Host` is carried now.

**ws early data** (`0f4e29a`) — share links were missing `ed=N`. Our inbound form defaults `early_data_header_name` to `Sec-WebSocket-Protocol`, so **every inbound with early data enabled was handing clients a link that could not use it**.

**Shadowsocks plugin** (`2aba316` + frontend `4eea15e`) — `?plugin=name;opts` in the `ss://` link, plus the two fields on both the inbound's client-side JSON and the Shadowsocks outbound form.

**Disabled TLS on an outbound** (`24ce6d2`) — `tls: {enabled: false}` was passed through to sing-box, which nil-pointers on it.

## Notes for review

- `sub/clashService.go` takes upstream's version wholesale. The local `sprtAll` type-switch from 709a7b7 is dropped because upstream's `proxyGroupList()` normalises both shapes up front — same fix, done earlier in the pipeline.
- The ws-header change is a **behaviour change**: a custom non-Host header set on an inbound will no longer reach Clash clients. That was never correct, but it is visible.
- Upstream's `78885b0` (Shadowsocks 2022 user lookup) is deliberately **not** ported: the `shadowsocks32` branch it added was removed again in upstream's own v1.5.4 release commit `56fa964`, leaving a pure refactor. Porting it alone would hand aes-256-gcm and chacha20-poly1305 clients an empty password.

## Verification

`go vet` and `go build -checklinkname=0` clean, `vue-tsc --noEmit` and `npm run build` clean. Both Shadowsocks plugin forms were exercised in a browser: the field renders, Plugin Options appears only once a plugin is set, and the value lands in `out_json`.

The repo has no tests, so the Clash and early-data changes are **not** covered by an automated check — they were read against upstream and compiled, not run against a real client.