### PR TITLE
Update inbound users in place instead of rebuilding the listener

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,14 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # core/protocol/*/inbound.go are verbatim sing-box copies. They keep
+      # compiling after a sing-box bump while silently running the old
+      # implementation, so vet and build cannot catch staleness -- only this can.
+      - name: Check vendored protocol copies
+        run: |
+          go mod download github.com/sagernet/sing-box
+          bash scripts/check-protocol-copies.sh
+
       - name: Vet
         run: go vet -tags "$BUILD_TAGS" ./...
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ The rest (`api/`, `service/`, `util/`, `cmd/`, `cronjob/`, `logger/`, `middlewar
 | `network/` | Not protocol code — ACME issuance, TLS config, and a listener that sniffs the first packet: plaintext HTTP hitting the HTTPS port gets a 307 to `https://`, anything else falls through to the TLS handshake. |
 | `app/` | One file. Lifecycle orchestration only (DB → settings → core → cron → both servers). |
 | `core/` | The sing-box wrapper. Business logic lives in `service/`. |
+| `core/protocol/` | **Verbatim copies of sing-box's own inbound implementations**, forked only so `UpdateUsers` can be attached (see below). Not a place to put new code. |
 
 ### The config assembly loop (the central mechanism)
 
@@ -92,6 +93,19 @@ This lives in `ConfigService.GetConfig` ([service/config.go](service/config.go))
 
 - Editing an entity means editing a **DB row**, then restarting the core. `ConfigService.Save` is the single write path: it opens a transaction, dispatches by object type, writes a `Changes` audit row, and bumps `LastUpdate` (which drives the frontend's `api/changes` poll).
 - `StartCore` is guarded by `startCoreMu` + a 15s `startCooldown` after a failure, and a `@every 5s` cron job (`checkCoreJob`) restarts the core if it's down. A failed config does not permanently wedge the panel, but it also means **your bad config will be retried on a loop** — read the log, don't just re-save.
+
+### `core/protocol/` — forked sing-box inbounds, and what it costs
+
+Editing a client used to go through `InboundService.RestartInbounds`, which removes the inbound from the core and adds it back. For the QUIC protocols that also destroys the QUIC session, so **changing one user dropped every connected user on that inbound**.
+
+sing-box keeps an inbound's user table in unexported fields and its `Inbound` types do not surface `UpdateUsers`. The underlying services (`*vless.Service`, …) do have it, but it is unreachable from outside the sing-box package. So seven inbounds (anytls, hysteria, hysteria2, trojan, tuic, vless, vmess) are **copied verbatim** into `core/protocol/`, `core/register.go` registers the copies, and `Core.UpdateInboundUsers` dispatches on the option type. Shadowsocks is not copied — sing-box already exports `MultiInbound.UpdateUsers`. Anything unrecognised returns `handled=false` and the caller falls back to the full restart; certificate changes (`service/tls.go`) keep restarting on purpose.
+
+Two things to internalise:
+
+- **The copies go stale silently.** They keep compiling after a sing-box bump while running the old implementation. `scripts/check-protocol-copies.sh` diffs them against the version in `go.mod` and runs in CI — **after bumping sing-box, expect it to fail**, and re-copy from the module cache rather than patching around it.
+- **`UpdateUsers` grows the name slice before the service learns the new users and shrinks it after.** That order is load-bearing: the service returns an index into that slice on every new connection, so the reverse order can index out of range. The two are still unsynchronised — as they are in sing-box itself — so a racing read can see a stale *name*, which only mis-labels a stat.
+
+Who gets disconnected is decided by `ConnTracker.CloseConnByInboundUsers`, matching on **user name**. Consequence: rotating a client's UUID or password does not drop its live connection.
 
 ### Model pattern: fixed columns + `Options` blob
 

--- a/core/inbound_users.go
+++ b/core/inbound_users.go
@@ -1,0 +1,73 @@
+package core
+
+import (
+	suiAnytls "github.com/shenaba/2s-ui/core/protocol/anytls"
+	suiHysteria "github.com/shenaba/2s-ui/core/protocol/hysteria"
+	suiHysteria2 "github.com/shenaba/2s-ui/core/protocol/hysteria2"
+	suiTrojan "github.com/shenaba/2s-ui/core/protocol/trojan"
+	suiTuic "github.com/shenaba/2s-ui/core/protocol/tuic"
+	suiVless "github.com/shenaba/2s-ui/core/protocol/vless"
+	suiVmess "github.com/shenaba/2s-ui/core/protocol/vmess"
+	"github.com/shenaba/2s-ui/util/common"
+
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/protocol/shadowsocks"
+	sbCommon "github.com/sagernet/sing/common"
+)
+
+func (c *Core) UpdateInboundUsers(config []byte) (bool, error) {
+	if !c.isRunning {
+		return false, common.NewError("sing-box is not running")
+	}
+	var inboundConfig option.Inbound
+	err := inboundConfig.UnmarshalJSONContext(c.GetCtx(), config)
+	if err != nil {
+		return false, err
+	}
+	inb, found := inbound_manager.Get(inboundConfig.Tag)
+	if !found {
+		return false, nil
+	}
+	switch options := inboundConfig.Options.(type) {
+	case *option.VLESSInboundOptions:
+		if in, ok := inb.(*suiVless.Inbound); ok {
+			return true, in.UpdateUsers(options.Users)
+		}
+	case *option.VMessInboundOptions:
+		if in, ok := inb.(*suiVmess.Inbound); ok {
+			return true, in.UpdateUsers(options.Users)
+		}
+	case *option.TrojanInboundOptions:
+		if in, ok := inb.(*suiTrojan.Inbound); ok {
+			return true, in.UpdateUsers(options.Users)
+		}
+	case *option.TUICInboundOptions:
+		if in, ok := inb.(*suiTuic.Inbound); ok {
+			return true, in.UpdateUsers(options.Users)
+		}
+	case *option.HysteriaInboundOptions:
+		if in, ok := inb.(*suiHysteria.Inbound); ok {
+			return true, in.UpdateUsers(options.Users)
+		}
+	case *option.Hysteria2InboundOptions:
+		if in, ok := inb.(*suiHysteria2.Inbound); ok {
+			return true, in.UpdateUsers(options.Users)
+		}
+	case *option.AnyTLSInboundOptions:
+		if in, ok := inb.(*suiAnytls.Inbound); ok {
+			return true, in.UpdateUsers(options.Users)
+		}
+	case *option.ShadowsocksInboundOptions:
+		if options.Managed || len(options.Users) == 0 {
+			return false, nil
+		}
+		if in, ok := inb.(*shadowsocks.MultiInbound); ok {
+			return true, in.UpdateUsers(sbCommon.Map(options.Users, func(it option.ShadowsocksUser) string {
+				return it.Name
+			}), sbCommon.Map(options.Users, func(it option.ShadowsocksUser) string {
+				return it.Password
+			}))
+		}
+	}
+	return false, nil
+}

--- a/core/inbound_users.go
+++ b/core/inbound_users.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (c *Core) UpdateInboundUsers(config []byte) (bool, error) {
-	if !c.isRunning {
+	if !c.IsRunning() {
 		return false, common.NewError("sing-box is not running")
 	}
 	var inboundConfig option.Inbound

--- a/core/protocol/anytls/inbound.go
+++ b/core/protocol/anytls/inbound.go
@@ -1,0 +1,145 @@
+// Verbatim copy of sing-box v1.13.14 protocol/anytls/inbound.go, moved into this
+// module so the panel can reach the unexported `service`/`users` fields that
+// the sing-box Inbound type does not expose. That access is what lets
+// core.UpdateInboundUsers swap an inbound's user table in place instead of
+// tearing the listener down (see core/inbound_users.go).
+//
+// UPGRADING sing-box: re-copy this file from the new tag and re-apply the
+// change below. Nothing here will fail to compile if you forget, it will just
+// silently keep running the old implementation.
+//
+// Local change vs sing-box: none, other than the package clause.
+package anytls
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/inbound"
+	"github.com/sagernet/sing-box/common/listener"
+	"github.com/sagernet/sing-box/common/tls"
+	"github.com/sagernet/sing-box/common/uot"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common"
+	"github.com/sagernet/sing/common/auth"
+	E "github.com/sagernet/sing/common/exceptions"
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+
+	anytls "github.com/anytls/sing-anytls"
+	"github.com/anytls/sing-anytls/padding"
+)
+
+func RegisterInbound(registry *inbound.Registry) {
+	inbound.Register[option.AnyTLSInboundOptions](registry, C.TypeAnyTLS, NewInbound)
+}
+
+type Inbound struct {
+	inbound.Adapter
+	tlsConfig tls.ServerConfig
+	router    adapter.ConnectionRouterEx
+	logger    logger.ContextLogger
+	listener  *listener.Listener
+	service   *anytls.Service
+}
+
+func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.AnyTLSInboundOptions) (adapter.Inbound, error) {
+	inbound := &Inbound{
+		Adapter: inbound.NewAdapter(C.TypeAnyTLS, tag),
+		router:  uot.NewRouter(router, logger),
+		logger:  logger,
+	}
+
+	if options.TLS != nil && options.TLS.Enabled {
+		tlsConfig, err := tls.NewServer(ctx, logger, common.PtrValueOrDefault(options.TLS))
+		if err != nil {
+			return nil, err
+		}
+		inbound.tlsConfig = tlsConfig
+	}
+
+	paddingScheme := padding.DefaultPaddingScheme
+	if len(options.PaddingScheme) > 0 {
+		paddingScheme = []byte(strings.Join(options.PaddingScheme, "\n"))
+	}
+
+	service, err := anytls.NewService(anytls.ServiceConfig{
+		Users: common.Map(options.Users, func(it option.AnyTLSUser) anytls.User {
+			return (anytls.User)(it)
+		}),
+		PaddingScheme: paddingScheme,
+		Handler:       (*inboundHandler)(inbound),
+		Logger:        logger,
+	})
+	if err != nil {
+		return nil, err
+	}
+	inbound.service = service
+	inbound.listener = listener.New(listener.Options{
+		Context:           ctx,
+		Logger:            logger,
+		Network:           []string{N.NetworkTCP},
+		Listen:            options.ListenOptions,
+		ConnectionHandler: inbound,
+	})
+	return inbound, nil
+}
+
+func (h *Inbound) Start(stage adapter.StartStage) error {
+	if stage != adapter.StartStateStart {
+		return nil
+	}
+	if h.tlsConfig != nil {
+		err := h.tlsConfig.Start()
+		if err != nil {
+			return err
+		}
+	}
+	return h.listener.Start()
+}
+
+func (h *Inbound) Close() error {
+	return common.Close(h.listener, h.tlsConfig)
+}
+
+func (h *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	if h.tlsConfig != nil {
+		tlsConn, err := tls.ServerHandshake(ctx, conn, h.tlsConfig)
+		if err != nil {
+			N.CloseOnHandshakeFailure(conn, onClose, err)
+			h.logger.ErrorContext(ctx, E.Cause(err, "process connection from ", metadata.Source, ": TLS handshake"))
+			return
+		}
+		conn = tlsConn
+	}
+	err := h.service.NewConnection(adapter.WithContext(ctx, &metadata), conn, metadata.Source, onClose)
+	if err != nil {
+		N.CloseOnHandshakeFailure(conn, onClose, err)
+		h.logger.ErrorContext(ctx, E.Cause(err, "process connection from ", metadata.Source))
+	}
+}
+
+type inboundHandler Inbound
+
+func (h *inboundHandler) NewConnectionEx(ctx context.Context, conn net.Conn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
+	var metadata adapter.InboundContext
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	//nolint:staticcheck
+	metadata.InboundDetour = h.listener.ListenOptions().Detour
+	//nolint:staticcheck
+	metadata.Source = source
+	metadata.Destination = destination.Unwrap()
+	if userName, _ := auth.UserFromContext[string](ctx); userName != "" {
+		metadata.User = userName
+		h.logger.InfoContext(ctx, "[", userName, "] inbound connection to ", metadata.Destination)
+	} else {
+		h.logger.InfoContext(ctx, "inbound connection to ", metadata.Destination)
+	}
+	h.router.RouteConnectionEx(ctx, conn, metadata, onClose)
+}

--- a/core/protocol/anytls/users.go
+++ b/core/protocol/anytls/users.go
@@ -1,0 +1,15 @@
+package anytls
+
+import (
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common"
+
+	anytls "github.com/anytls/sing-anytls"
+)
+
+func (h *Inbound) UpdateUsers(users []option.AnyTLSUser) error {
+	h.service.UpdateUsers(common.Map(users, func(it option.AnyTLSUser) anytls.User {
+		return (anytls.User)(it)
+	}))
+	return nil
+}

--- a/core/protocol/hysteria/inbound.go
+++ b/core/protocol/hysteria/inbound.go
@@ -1,0 +1,191 @@
+// Verbatim copy of sing-box v1.13.14 protocol/hysteria/inbound.go, moved into this
+// module so the panel can reach the unexported `service`/`users` fields that
+// the sing-box Inbound type does not expose. That access is what lets
+// core.UpdateInboundUsers swap an inbound's user table in place instead of
+// tearing the listener down (see core/inbound_users.go).
+//
+// UPGRADING sing-box: re-copy this file from the new tag and re-apply the
+// change below. Nothing here will fail to compile if you forget, it will just
+// silently keep running the old implementation.
+//
+// Local change vs sing-box: none, other than the package clause.
+package hysteria
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/inbound"
+	"github.com/sagernet/sing-box/common/listener"
+	"github.com/sagernet/sing-box/common/tls"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-quic/hysteria"
+	"github.com/sagernet/sing/common"
+	"github.com/sagernet/sing/common/auth"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+)
+
+func RegisterInbound(registry *inbound.Registry) {
+	inbound.Register[option.HysteriaInboundOptions](registry, C.TypeHysteria, NewInbound)
+}
+
+type Inbound struct {
+	inbound.Adapter
+	router       adapter.Router
+	logger       log.ContextLogger
+	listener     *listener.Listener
+	tlsConfig    tls.ServerConfig
+	service      *hysteria.Service[int]
+	userNameList []string
+}
+
+func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.HysteriaInboundOptions) (adapter.Inbound, error) {
+	options.UDPFragmentDefault = true
+	if options.TLS == nil || !options.TLS.Enabled {
+		return nil, C.ErrTLSRequired
+	}
+	tlsConfig, err := tls.NewServer(ctx, logger, common.PtrValueOrDefault(options.TLS))
+	if err != nil {
+		return nil, err
+	}
+	inbound := &Inbound{
+		Adapter: inbound.NewAdapter(C.TypeHysteria, tag),
+		router:  router,
+		logger:  logger,
+		listener: listener.New(listener.Options{
+			Context: ctx,
+			Logger:  logger,
+			Listen:  options.ListenOptions,
+		}),
+		tlsConfig: tlsConfig,
+	}
+	var sendBps, receiveBps uint64
+	if options.Up.Value() > 0 {
+		sendBps = options.Up.Value()
+	} else {
+		sendBps = uint64(options.UpMbps) * hysteria.MbpsToBps
+	}
+	if options.Down.Value() > 0 {
+		receiveBps = options.Down.Value()
+	} else {
+		receiveBps = uint64(options.DownMbps) * hysteria.MbpsToBps
+	}
+	var udpTimeout time.Duration
+	if options.UDPTimeout != 0 {
+		udpTimeout = time.Duration(options.UDPTimeout)
+	} else {
+		udpTimeout = C.UDPTimeout
+	}
+	service, err := hysteria.NewService[int](hysteria.ServiceOptions{
+		Context:       ctx,
+		Logger:        logger,
+		SendBPS:       sendBps,
+		ReceiveBPS:    receiveBps,
+		XPlusPassword: options.Obfs,
+		TLSConfig:     tlsConfig,
+		UDPTimeout:    udpTimeout,
+		Handler:       inbound,
+
+		// Legacy options
+
+		ConnReceiveWindow:   options.ReceiveWindowConn,
+		StreamReceiveWindow: options.ReceiveWindowClient,
+		MaxIncomingStreams:  int64(options.MaxConnClient),
+		DisableMTUDiscovery: options.DisableMTUDiscovery,
+	})
+	if err != nil {
+		return nil, err
+	}
+	userList := make([]int, 0, len(options.Users))
+	userNameList := make([]string, 0, len(options.Users))
+	userPasswordList := make([]string, 0, len(options.Users))
+	for index, user := range options.Users {
+		userList = append(userList, index)
+		userNameList = append(userNameList, user.Name)
+		var password string
+		if user.AuthString != "" {
+			password = user.AuthString
+		} else {
+			password = string(user.Auth)
+		}
+		userPasswordList = append(userPasswordList, password)
+	}
+	service.UpdateUsers(userList, userPasswordList)
+	inbound.service = service
+	inbound.userNameList = userNameList
+	return inbound, nil
+}
+
+func (h *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
+	ctx = log.ContextWithNewID(ctx)
+	var metadata adapter.InboundContext
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	//nolint:staticcheck
+	metadata.InboundDetour = h.listener.ListenOptions().Detour
+	//nolint:staticcheck
+	metadata.OriginDestination = h.listener.UDPAddr()
+	metadata.Source = source
+	metadata.Destination = destination
+	h.logger.InfoContext(ctx, "inbound connection from ", metadata.Source)
+	userID, _ := auth.UserFromContext[int](ctx)
+	if userName := h.userNameList[userID]; userName != "" {
+		metadata.User = userName
+		h.logger.InfoContext(ctx, "[", userName, "] inbound connection to ", metadata.Destination)
+	} else {
+		h.logger.InfoContext(ctx, "inbound connection to ", metadata.Destination)
+	}
+	h.router.RouteConnectionEx(ctx, conn, metadata, onClose)
+}
+
+func (h *Inbound) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
+	ctx = log.ContextWithNewID(ctx)
+	var metadata adapter.InboundContext
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	//nolint:staticcheck
+	metadata.InboundDetour = h.listener.ListenOptions().Detour
+	//nolint:staticcheck
+	metadata.OriginDestination = h.listener.UDPAddr()
+	metadata.Source = source
+	metadata.Destination = destination
+	h.logger.InfoContext(ctx, "inbound packet connection from ", metadata.Source)
+	userID, _ := auth.UserFromContext[int](ctx)
+	if userName := h.userNameList[userID]; userName != "" {
+		metadata.User = userName
+		h.logger.InfoContext(ctx, "[", userName, "] inbound packet connection to ", metadata.Destination)
+	} else {
+		h.logger.InfoContext(ctx, "inbound packet connection to ", metadata.Destination)
+	}
+	h.router.RoutePacketConnectionEx(ctx, conn, metadata, onClose)
+}
+
+func (h *Inbound) Start(stage adapter.StartStage) error {
+	if stage != adapter.StartStateStart {
+		return nil
+	}
+	if h.tlsConfig != nil {
+		err := h.tlsConfig.Start()
+		if err != nil {
+			return err
+		}
+	}
+	packetConn, err := h.listener.ListenUDP()
+	if err != nil {
+		return err
+	}
+	return h.service.Start(packetConn)
+}
+
+func (h *Inbound) Close() error {
+	return common.Close(
+		h.listener,
+		h.tlsConfig,
+		common.PtrOrNil(h.service),
+	)
+}

--- a/core/protocol/hysteria/users.go
+++ b/core/protocol/hysteria/users.go
@@ -1,0 +1,25 @@
+package hysteria
+
+import (
+	"github.com/sagernet/sing-box/option"
+)
+
+func (h *Inbound) UpdateUsers(users []option.HysteriaUser) error {
+	userList := make([]int, 0, len(users))
+	userNameList := make([]string, 0, len(users))
+	userPasswordList := make([]string, 0, len(users))
+	for index, user := range users {
+		userList = append(userList, index)
+		userNameList = append(userNameList, user.Name)
+		var password string
+		if user.AuthString != "" {
+			password = user.AuthString
+		} else {
+			password = string(user.Auth)
+		}
+		userPasswordList = append(userPasswordList, password)
+	}
+	h.service.UpdateUsers(userList, userPasswordList)
+	h.userNameList = userNameList
+	return nil
+}

--- a/core/protocol/hysteria/users.go
+++ b/core/protocol/hysteria/users.go
@@ -19,6 +19,15 @@ func (h *Inbound) UpdateUsers(users []option.HysteriaUser) error {
 		}
 		userPasswordList = append(userPasswordList, password)
 	}
+	// Grow before the service learns the new users, shrink after it forgets the
+	// old ones. The service hands back an index into userNameList on every new
+	// connection, so it must never know about more users than the slice holds
+	// or that index goes out of range. (The two are still unsynchronised, as
+	// they are in sing-box itself -- a racing read can see a stale name, which
+	// only mis-labels a stat. Out of range would take down the process.)
+	if len(userNameList) > len(h.userNameList) {
+		h.userNameList = userNameList
+	}
 	h.service.UpdateUsers(userList, userPasswordList)
 	h.userNameList = userNameList
 	return nil

--- a/core/protocol/hysteria2/inbound.go
+++ b/core/protocol/hysteria2/inbound.go
@@ -1,0 +1,224 @@
+// Verbatim copy of sing-box v1.13.14 protocol/hysteria2/inbound.go, moved into this
+// module so the panel can reach the unexported `service`/`users` fields that
+// the sing-box Inbound type does not expose. That access is what lets
+// core.UpdateInboundUsers swap an inbound's user table in place instead of
+// tearing the listener down (see core/inbound_users.go).
+//
+// UPGRADING sing-box: re-copy this file from the new tag and re-apply the
+// change below. Nothing here will fail to compile if you forget, it will just
+// silently keep running the old implementation.
+//
+// Local change vs sing-box: none, other than the package clause.
+package hysteria2
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/inbound"
+	"github.com/sagernet/sing-box/common/listener"
+	"github.com/sagernet/sing-box/common/tls"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-quic/hysteria"
+	"github.com/sagernet/sing-quic/hysteria2"
+	"github.com/sagernet/sing/common"
+	"github.com/sagernet/sing/common/auth"
+	E "github.com/sagernet/sing/common/exceptions"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+)
+
+func RegisterInbound(registry *inbound.Registry) {
+	inbound.Register[option.Hysteria2InboundOptions](registry, C.TypeHysteria2, NewInbound)
+}
+
+type Inbound struct {
+	inbound.Adapter
+	router       adapter.Router
+	logger       log.ContextLogger
+	listener     *listener.Listener
+	tlsConfig    tls.ServerConfig
+	service      *hysteria2.Service[int]
+	userNameList []string
+}
+
+func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.Hysteria2InboundOptions) (adapter.Inbound, error) {
+	options.UDPFragmentDefault = true
+	if options.TLS == nil || !options.TLS.Enabled {
+		return nil, C.ErrTLSRequired
+	}
+	tlsConfig, err := tls.NewServer(ctx, logger, common.PtrValueOrDefault(options.TLS))
+	if err != nil {
+		return nil, err
+	}
+	var salamanderPassword string
+	if options.Obfs != nil {
+		if options.Obfs.Password == "" {
+			return nil, E.New("missing obfs password")
+		}
+		switch options.Obfs.Type {
+		case hysteria2.ObfsTypeSalamander:
+			salamanderPassword = options.Obfs.Password
+		default:
+			return nil, E.New("unknown obfs type: ", options.Obfs.Type)
+		}
+	}
+	var masqueradeHandler http.Handler
+	if options.Masquerade != nil && options.Masquerade.Type != "" {
+		switch options.Masquerade.Type {
+		case C.Hysterai2MasqueradeTypeFile:
+			masqueradeHandler = http.FileServer(http.Dir(options.Masquerade.FileOptions.Directory))
+		case C.Hysterai2MasqueradeTypeProxy:
+			masqueradeURL, err := url.Parse(options.Masquerade.ProxyOptions.URL)
+			if err != nil {
+				return nil, E.Cause(err, "parse masquerade URL")
+			}
+			masqueradeHandler = &httputil.ReverseProxy{
+				Rewrite: func(r *httputil.ProxyRequest) {
+					r.SetURL(masqueradeURL)
+					if !options.Masquerade.ProxyOptions.RewriteHost {
+						r.Out.Host = r.In.Host
+					}
+				},
+				ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+					w.WriteHeader(http.StatusBadGateway)
+				},
+			}
+		case C.Hysterai2MasqueradeTypeString:
+			masqueradeHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if options.Masquerade.StringOptions.StatusCode != 0 {
+					w.WriteHeader(options.Masquerade.StringOptions.StatusCode)
+				}
+				for key, values := range options.Masquerade.StringOptions.Headers {
+					for _, value := range values {
+						w.Header().Add(key, value)
+					}
+				}
+				w.Write([]byte(options.Masquerade.StringOptions.Content))
+			})
+		default:
+			return nil, E.New("unknown masquerade type: ", options.Masquerade.Type)
+		}
+	}
+	inbound := &Inbound{
+		Adapter: inbound.NewAdapter(C.TypeHysteria2, tag),
+		router:  router,
+		logger:  logger,
+		listener: listener.New(listener.Options{
+			Context: ctx,
+			Logger:  logger,
+			Listen:  options.ListenOptions,
+		}),
+		tlsConfig: tlsConfig,
+	}
+	var udpTimeout time.Duration
+	if options.UDPTimeout != 0 {
+		udpTimeout = time.Duration(options.UDPTimeout)
+	} else {
+		udpTimeout = C.UDPTimeout
+	}
+	service, err := hysteria2.NewService[int](hysteria2.ServiceOptions{
+		Context:               ctx,
+		Logger:                logger,
+		BrutalDebug:           options.BrutalDebug,
+		SendBPS:               uint64(options.UpMbps * hysteria.MbpsToBps),
+		ReceiveBPS:            uint64(options.DownMbps * hysteria.MbpsToBps),
+		SalamanderPassword:    salamanderPassword,
+		TLSConfig:             tlsConfig,
+		IgnoreClientBandwidth: options.IgnoreClientBandwidth,
+		UDPTimeout:            udpTimeout,
+		Handler:               inbound,
+		MasqueradeHandler:     masqueradeHandler,
+	})
+	if err != nil {
+		return nil, err
+	}
+	userList := make([]int, 0, len(options.Users))
+	userNameList := make([]string, 0, len(options.Users))
+	userPasswordList := make([]string, 0, len(options.Users))
+	for index, user := range options.Users {
+		userList = append(userList, index)
+		userNameList = append(userNameList, user.Name)
+		userPasswordList = append(userPasswordList, user.Password)
+	}
+	service.UpdateUsers(userList, userPasswordList)
+	inbound.service = service
+	inbound.userNameList = userNameList
+	return inbound, nil
+}
+
+func (h *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
+	ctx = log.ContextWithNewID(ctx)
+	var metadata adapter.InboundContext
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	//nolint:staticcheck
+	metadata.InboundDetour = h.listener.ListenOptions().Detour
+	//nolint:staticcheck
+	metadata.OriginDestination = h.listener.UDPAddr()
+	metadata.Source = source
+	metadata.Destination = destination
+	h.logger.InfoContext(ctx, "inbound connection from ", metadata.Source)
+	userID, _ := auth.UserFromContext[int](ctx)
+	if userName := h.userNameList[userID]; userName != "" {
+		metadata.User = userName
+		h.logger.InfoContext(ctx, "[", userName, "] inbound connection to ", metadata.Destination)
+	} else {
+		h.logger.InfoContext(ctx, "inbound connection to ", metadata.Destination)
+	}
+	h.router.RouteConnectionEx(ctx, conn, metadata, onClose)
+}
+
+func (h *Inbound) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
+	ctx = log.ContextWithNewID(ctx)
+	var metadata adapter.InboundContext
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	//nolint:staticcheck
+	metadata.InboundDetour = h.listener.ListenOptions().Detour
+	//nolint:staticcheck
+	metadata.OriginDestination = h.listener.UDPAddr()
+	metadata.Source = source
+	metadata.Destination = destination
+	h.logger.InfoContext(ctx, "inbound packet connection from ", metadata.Source)
+	userID, _ := auth.UserFromContext[int](ctx)
+	if userName := h.userNameList[userID]; userName != "" {
+		metadata.User = userName
+		h.logger.InfoContext(ctx, "[", userName, "] inbound packet connection to ", metadata.Destination)
+	} else {
+		h.logger.InfoContext(ctx, "inbound packet connection to ", metadata.Destination)
+	}
+	h.router.RoutePacketConnectionEx(ctx, conn, metadata, onClose)
+}
+
+func (h *Inbound) Start(stage adapter.StartStage) error {
+	if stage != adapter.StartStateStart {
+		return nil
+	}
+	if h.tlsConfig != nil {
+		err := h.tlsConfig.Start()
+		if err != nil {
+			return err
+		}
+	}
+	packetConn, err := h.listener.ListenUDP()
+	if err != nil {
+		return err
+	}
+	return h.service.Start(packetConn)
+}
+
+func (h *Inbound) Close() error {
+	return common.Close(
+		h.listener,
+		h.tlsConfig,
+		common.PtrOrNil(h.service),
+	)
+}

--- a/core/protocol/hysteria2/users.go
+++ b/core/protocol/hysteria2/users.go
@@ -1,0 +1,19 @@
+package hysteria2
+
+import (
+	"github.com/sagernet/sing-box/option"
+)
+
+func (h *Inbound) UpdateUsers(users []option.Hysteria2User) error {
+	userList := make([]int, 0, len(users))
+	userNameList := make([]string, 0, len(users))
+	userPasswordList := make([]string, 0, len(users))
+	for index, user := range users {
+		userList = append(userList, index)
+		userNameList = append(userNameList, user.Name)
+		userPasswordList = append(userPasswordList, user.Password)
+	}
+	h.service.UpdateUsers(userList, userPasswordList)
+	h.userNameList = userNameList
+	return nil
+}

--- a/core/protocol/hysteria2/users.go
+++ b/core/protocol/hysteria2/users.go
@@ -13,6 +13,11 @@ func (h *Inbound) UpdateUsers(users []option.Hysteria2User) error {
 		userNameList = append(userNameList, user.Name)
 		userPasswordList = append(userPasswordList, user.Password)
 	}
+	// Grow before the service learns the new users, shrink after. See the
+	// comment in core/protocol/hysteria/users.go for why the order matters.
+	if len(userNameList) > len(h.userNameList) {
+		h.userNameList = userNameList
+	}
 	h.service.UpdateUsers(userList, userPasswordList)
 	h.userNameList = userNameList
 	return nil

--- a/core/protocol/trojan/inbound.go
+++ b/core/protocol/trojan/inbound.go
@@ -1,0 +1,273 @@
+// Verbatim copy of sing-box v1.13.14 protocol/trojan/inbound.go, moved into this
+// module so the panel can reach the unexported `service`/`users` fields that
+// the sing-box Inbound type does not expose. That access is what lets
+// core.UpdateInboundUsers swap an inbound's user table in place instead of
+// tearing the listener down (see core/inbound_users.go).
+//
+// UPGRADING sing-box: re-copy this file from the new tag and re-apply the
+// change below. Nothing here will fail to compile if you forget, it will just
+// silently keep running the old implementation.
+//
+// Local change vs sing-box: none, other than the package clause.
+package trojan
+
+import (
+	"context"
+	"net"
+	"os"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/inbound"
+	"github.com/sagernet/sing-box/common/listener"
+	"github.com/sagernet/sing-box/common/mux"
+	"github.com/sagernet/sing-box/common/tls"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/transport/trojan"
+	"github.com/sagernet/sing-box/transport/v2ray"
+	"github.com/sagernet/sing/common"
+	"github.com/sagernet/sing/common/auth"
+	E "github.com/sagernet/sing/common/exceptions"
+	F "github.com/sagernet/sing/common/format"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+)
+
+func RegisterInbound(registry *inbound.Registry) {
+	inbound.Register[option.TrojanInboundOptions](registry, C.TypeTrojan, NewInbound)
+}
+
+var _ adapter.TCPInjectableInbound = (*Inbound)(nil)
+
+type Inbound struct {
+	inbound.Adapter
+	router                   adapter.ConnectionRouterEx
+	logger                   log.ContextLogger
+	listener                 *listener.Listener
+	service                  *trojan.Service[int]
+	users                    []option.TrojanUser
+	tlsConfig                tls.ServerConfig
+	fallbackAddr             M.Socksaddr
+	fallbackAddrTLSNextProto map[string]M.Socksaddr
+	transport                adapter.V2RayServerTransport
+}
+
+func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.TrojanInboundOptions) (adapter.Inbound, error) {
+	inbound := &Inbound{
+		Adapter: inbound.NewAdapter(C.TypeTrojan, tag),
+		router:  router,
+		logger:  logger,
+		users:   options.Users,
+	}
+	if options.TLS != nil {
+		tlsConfig, err := tls.NewServerWithOptions(tls.ServerOptions{
+			Context: ctx,
+			Logger:  logger,
+			Options: common.PtrValueOrDefault(options.TLS),
+			KTLSCompatible: common.PtrValueOrDefault(options.Transport).Type == "" &&
+				!common.PtrValueOrDefault(options.Multiplex).Enabled,
+		})
+		if err != nil {
+			return nil, err
+		}
+		inbound.tlsConfig = tlsConfig
+	}
+	var fallbackHandler N.TCPConnectionHandlerEx
+	if options.Fallback != nil && options.Fallback.Server != "" || len(options.FallbackForALPN) > 0 {
+		if options.Fallback != nil && options.Fallback.Server != "" {
+			inbound.fallbackAddr = options.Fallback.Build()
+			if !inbound.fallbackAddr.IsValid() {
+				return nil, E.New("invalid fallback address: ", inbound.fallbackAddr)
+			}
+		}
+		if len(options.FallbackForALPN) > 0 {
+			if inbound.tlsConfig == nil {
+				return nil, E.New("fallback for ALPN is not supported without TLS")
+			}
+			fallbackAddrNextProto := make(map[string]M.Socksaddr)
+			for nextProto, destination := range options.FallbackForALPN {
+				fallbackAddr := destination.Build()
+				if !fallbackAddr.IsValid() {
+					return nil, E.New("invalid fallback address for ALPN ", nextProto, ": ", fallbackAddr)
+				}
+				fallbackAddrNextProto[nextProto] = fallbackAddr
+			}
+			inbound.fallbackAddrTLSNextProto = fallbackAddrNextProto
+		}
+		fallbackHandler = adapter.NewUpstreamContextHandlerEx(inbound.fallbackConnection, nil)
+	}
+	service := trojan.NewService[int](adapter.NewUpstreamContextHandlerEx(inbound.newConnection, inbound.newPacketConnection), fallbackHandler, logger)
+	err := service.UpdateUsers(common.MapIndexed(options.Users, func(index int, it option.TrojanUser) int {
+		return index
+	}), common.Map(options.Users, func(it option.TrojanUser) string {
+		return it.Password
+	}))
+	if err != nil {
+		return nil, err
+	}
+	if options.Transport != nil {
+		inbound.transport, err = v2ray.NewServerTransport(ctx, logger, common.PtrValueOrDefault(options.Transport), inbound.tlsConfig, (*inboundTransportHandler)(inbound))
+		if err != nil {
+			return nil, E.Cause(err, "create server transport: ", options.Transport.Type)
+		}
+	}
+	inbound.router, err = mux.NewRouterWithOptions(inbound.router, logger, common.PtrValueOrDefault(options.Multiplex))
+	if err != nil {
+		return nil, err
+	}
+	inbound.service = service
+	inbound.listener = listener.New(listener.Options{
+		Context:           ctx,
+		Logger:            logger,
+		Network:           []string{N.NetworkTCP},
+		Listen:            options.ListenOptions,
+		ConnectionHandler: inbound,
+	})
+	return inbound, nil
+}
+
+func (h *Inbound) Start(stage adapter.StartStage) error {
+	if stage != adapter.StartStateStart {
+		return nil
+	}
+	if h.tlsConfig != nil {
+		err := h.tlsConfig.Start()
+		if err != nil {
+			return E.Cause(err, "create TLS config")
+		}
+	}
+	if h.transport == nil {
+		return h.listener.Start()
+	}
+	if common.Contains(h.transport.Network(), N.NetworkTCP) {
+		tcpListener, err := h.listener.ListenTCP()
+		if err != nil {
+			return err
+		}
+		go func() {
+			sErr := h.transport.Serve(tcpListener)
+			if sErr != nil && !E.IsClosed(sErr) {
+				h.logger.Error("transport serve error: ", sErr)
+			}
+		}()
+	}
+	if common.Contains(h.transport.Network(), N.NetworkUDP) {
+		udpConn, err := h.listener.ListenUDP()
+		if err != nil {
+			return err
+		}
+		go func() {
+			sErr := h.transport.ServePacket(udpConn)
+			if sErr != nil && !E.IsClosed(sErr) {
+				h.logger.Error("transport serve error: ", sErr)
+			}
+		}()
+	}
+	return nil
+}
+
+func (h *Inbound) Close() error {
+	return common.Close(
+		h.listener,
+		h.tlsConfig,
+		h.transport,
+	)
+}
+
+func (h *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	if h.tlsConfig != nil && h.transport == nil {
+		tlsConn, err := tls.ServerHandshake(ctx, conn, h.tlsConfig)
+		if err != nil {
+			N.CloseOnHandshakeFailure(conn, onClose, err)
+			h.logger.ErrorContext(ctx, E.Cause(err, "process connection from ", metadata.Source, ": TLS handshake"))
+			return
+		}
+		conn = tlsConn
+	}
+	err := h.service.NewConnection(adapter.WithContext(ctx, &metadata), conn, metadata.Source, onClose)
+	if err != nil {
+		N.CloseOnHandshakeFailure(conn, onClose, err)
+		h.logger.ErrorContext(ctx, E.Cause(err, "process connection from ", metadata.Source))
+	}
+}
+
+func (h *Inbound) newConnection(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	userIndex, loaded := auth.UserFromContext[int](ctx)
+	if !loaded {
+		N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
+		return
+	}
+	user := h.users[userIndex].Name
+	if user == "" {
+		user = F.ToString(userIndex)
+	} else {
+		metadata.User = user
+	}
+	h.logger.InfoContext(ctx, "[", user, "] inbound connection to ", metadata.Destination)
+	h.router.RouteConnectionEx(ctx, conn, metadata, onClose)
+}
+
+func (h *Inbound) newPacketConnection(ctx context.Context, conn N.PacketConn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	userIndex, loaded := auth.UserFromContext[int](ctx)
+	if !loaded {
+		N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
+		return
+	}
+	user := h.users[userIndex].Name
+	if user == "" {
+		user = F.ToString(userIndex)
+	} else {
+		metadata.User = user
+	}
+	h.logger.InfoContext(ctx, "[", user, "] inbound packet connection to ", metadata.Destination)
+	h.router.RoutePacketConnectionEx(ctx, conn, metadata, onClose)
+}
+
+func (h *Inbound) fallbackConnection(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	var fallbackAddr M.Socksaddr
+	if len(h.fallbackAddrTLSNextProto) > 0 {
+		if tlsConn, loaded := common.Cast[tls.Conn](conn); loaded {
+			connectionState := tlsConn.ConnectionState()
+			if connectionState.NegotiatedProtocol != "" {
+				if fallbackAddr, loaded = h.fallbackAddrTLSNextProto[connectionState.NegotiatedProtocol]; !loaded {
+					h.logger.DebugContext(ctx, "process connection from ", metadata.Source, ": fallback disabled for ALPN: ", connectionState.NegotiatedProtocol)
+					N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
+					return
+				}
+			}
+		}
+	}
+	if !fallbackAddr.IsValid() {
+		if !h.fallbackAddr.IsValid() {
+			h.logger.DebugContext(ctx, "process connection from ", metadata.Source, ": fallback disabled by default")
+			N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
+			return
+		}
+		fallbackAddr = h.fallbackAddr
+	}
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	metadata.Destination = fallbackAddr
+	h.logger.InfoContext(ctx, "fallback connection to ", fallbackAddr)
+	h.router.RouteConnectionEx(ctx, conn, metadata, onClose)
+}
+
+var _ adapter.V2RayServerTransportHandler = (*inboundTransportHandler)(nil)
+
+type inboundTransportHandler Inbound
+
+func (h *inboundTransportHandler) NewConnectionEx(ctx context.Context, conn net.Conn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
+	var metadata adapter.InboundContext
+	metadata.Source = source
+	metadata.Destination = destination
+	//nolint:staticcheck
+	metadata.InboundDetour = h.listener.ListenOptions().Detour
+	//nolint:staticcheck
+	h.logger.InfoContext(ctx, "inbound connection from ", metadata.Source)
+	(*Inbound)(h).NewConnectionEx(ctx, conn, metadata, onClose)
+}

--- a/core/protocol/trojan/users.go
+++ b/core/protocol/trojan/users.go
@@ -1,0 +1,19 @@
+package trojan
+
+import (
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common"
+)
+
+func (h *Inbound) UpdateUsers(users []option.TrojanUser) error {
+	err := h.service.UpdateUsers(common.MapIndexed(users, func(index int, _ option.TrojanUser) int {
+		return index
+	}), common.Map(users, func(it option.TrojanUser) string {
+		return it.Password
+	}))
+	if err != nil {
+		return err
+	}
+	h.users = users
+	return nil
+}

--- a/core/protocol/trojan/users.go
+++ b/core/protocol/trojan/users.go
@@ -6,6 +6,13 @@ import (
 )
 
 func (h *Inbound) UpdateUsers(users []option.TrojanUser) error {
+	// Grow before the service learns the new users, shrink after. See the
+	// comment in core/protocol/hysteria/users.go for why the order matters.
+	// On a failed update the list stays grown, which is harmless: every index
+	// the service can still produce is in range, only the name may be stale.
+	if len(users) > len(h.users) {
+		h.users = users
+	}
 	err := h.service.UpdateUsers(common.MapIndexed(users, func(index int, _ option.TrojanUser) int {
 		return index
 	}), common.Map(users, func(it option.TrojanUser) string {

--- a/core/protocol/tuic/inbound.go
+++ b/core/protocol/tuic/inbound.go
@@ -1,0 +1,181 @@
+// Verbatim copy of sing-box v1.13.14 protocol/tuic/inbound.go, moved into this
+// module so the panel can reach the unexported `service`/`users` fields that
+// the sing-box Inbound type does not expose. That access is what lets
+// core.UpdateInboundUsers swap an inbound's user table in place instead of
+// tearing the listener down (see core/inbound_users.go).
+//
+// UPGRADING sing-box: re-copy this file from the new tag and re-apply the
+// change below. Nothing here will fail to compile if you forget, it will just
+// silently keep running the old implementation.
+//
+// Local change vs sing-box: none, other than the package clause.
+package tuic
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/inbound"
+	"github.com/sagernet/sing-box/common/listener"
+	"github.com/sagernet/sing-box/common/tls"
+	"github.com/sagernet/sing-box/common/uot"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-quic/tuic"
+	"github.com/sagernet/sing/common"
+	"github.com/sagernet/sing/common/auth"
+	E "github.com/sagernet/sing/common/exceptions"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+
+	"github.com/gofrs/uuid/v5"
+)
+
+func RegisterInbound(registry *inbound.Registry) {
+	inbound.Register[option.TUICInboundOptions](registry, C.TypeTUIC, NewInbound)
+}
+
+type Inbound struct {
+	inbound.Adapter
+	router       adapter.ConnectionRouterEx
+	logger       log.ContextLogger
+	listener     *listener.Listener
+	tlsConfig    tls.ServerConfig
+	server       *tuic.Service[int]
+	userNameList []string
+}
+
+func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.TUICInboundOptions) (adapter.Inbound, error) {
+	options.UDPFragmentDefault = true
+	if options.TLS == nil || !options.TLS.Enabled {
+		return nil, C.ErrTLSRequired
+	}
+	tlsConfig, err := tls.NewServer(ctx, logger, common.PtrValueOrDefault(options.TLS))
+	if err != nil {
+		return nil, err
+	}
+	inbound := &Inbound{
+		Adapter: inbound.NewAdapter(C.TypeTUIC, tag),
+		router:  uot.NewRouter(router, logger),
+		logger:  logger,
+		listener: listener.New(listener.Options{
+			Context: ctx,
+			Logger:  logger,
+			Listen:  options.ListenOptions,
+		}),
+		tlsConfig: tlsConfig,
+	}
+	var udpTimeout time.Duration
+	if options.UDPTimeout != 0 {
+		udpTimeout = time.Duration(options.UDPTimeout)
+	} else {
+		udpTimeout = C.UDPTimeout
+	}
+	service, err := tuic.NewService[int](tuic.ServiceOptions{
+		Context:           ctx,
+		Logger:            logger,
+		TLSConfig:         tlsConfig,
+		CongestionControl: options.CongestionControl,
+		AuthTimeout:       time.Duration(options.AuthTimeout),
+		ZeroRTTHandshake:  options.ZeroRTTHandshake,
+		Heartbeat:         time.Duration(options.Heartbeat),
+		UDPTimeout:        udpTimeout,
+		Handler:           inbound,
+	})
+	if err != nil {
+		return nil, err
+	}
+	var userList []int
+	var userNameList []string
+	var userUUIDList [][16]byte
+	var userPasswordList []string
+	for index, user := range options.Users {
+		if user.UUID == "" {
+			return nil, E.New("missing uuid for user ", index)
+		}
+		userUUID, err := uuid.FromString(user.UUID)
+		if err != nil {
+			return nil, E.Cause(err, "invalid uuid for user ", index)
+		}
+		userList = append(userList, index)
+		userNameList = append(userNameList, user.Name)
+		userUUIDList = append(userUUIDList, userUUID)
+		userPasswordList = append(userPasswordList, user.Password)
+	}
+	service.UpdateUsers(userList, userUUIDList, userPasswordList)
+	inbound.server = service
+	inbound.userNameList = userNameList
+	return inbound, nil
+}
+
+func (h *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
+	ctx = log.ContextWithNewID(ctx)
+	var metadata adapter.InboundContext
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	//nolint:staticcheck
+	metadata.InboundDetour = h.listener.ListenOptions().Detour
+	//nolint:staticcheck
+	metadata.OriginDestination = h.listener.UDPAddr()
+	metadata.Source = source
+	metadata.Destination = destination
+	h.logger.InfoContext(ctx, "inbound connection from ", metadata.Source)
+	userID, _ := auth.UserFromContext[int](ctx)
+	if userName := h.userNameList[userID]; userName != "" {
+		metadata.User = userName
+		h.logger.InfoContext(ctx, "[", userName, "] inbound connection to ", metadata.Destination)
+	} else {
+		h.logger.InfoContext(ctx, "inbound connection to ", metadata.Destination)
+	}
+	h.router.RouteConnectionEx(ctx, conn, metadata, onClose)
+}
+
+func (h *Inbound) NewPacketConnectionEx(ctx context.Context, conn N.PacketConn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
+	ctx = log.ContextWithNewID(ctx)
+	var metadata adapter.InboundContext
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	//nolint:staticcheck
+	metadata.InboundDetour = h.listener.ListenOptions().Detour
+	//nolint:staticcheck
+	metadata.OriginDestination = h.listener.UDPAddr()
+	metadata.Source = source
+	metadata.Destination = destination
+	h.logger.InfoContext(ctx, "inbound packet connection from ", metadata.Source)
+	userID, _ := auth.UserFromContext[int](ctx)
+	if userName := h.userNameList[userID]; userName != "" {
+		metadata.User = userName
+		h.logger.InfoContext(ctx, "[", userName, "] inbound packet connection to ", metadata.Destination)
+	} else {
+		h.logger.InfoContext(ctx, "inbound packet connection to ", metadata.Destination)
+	}
+	h.router.RoutePacketConnectionEx(ctx, conn, metadata, onClose)
+}
+
+func (h *Inbound) Start(stage adapter.StartStage) error {
+	if stage != adapter.StartStateStart {
+		return nil
+	}
+	if h.tlsConfig != nil {
+		err := h.tlsConfig.Start()
+		if err != nil {
+			return err
+		}
+	}
+	packetConn, err := h.listener.ListenUDP()
+	if err != nil {
+		return err
+	}
+	return h.server.Start(packetConn)
+}
+
+func (h *Inbound) Close() error {
+	return common.Close(
+		h.listener,
+		h.tlsConfig,
+		common.PtrOrNil(h.server),
+	)
+}

--- a/core/protocol/tuic/users.go
+++ b/core/protocol/tuic/users.go
@@ -1,0 +1,31 @@
+package tuic
+
+import (
+	"github.com/sagernet/sing-box/option"
+	E "github.com/sagernet/sing/common/exceptions"
+
+	"github.com/gofrs/uuid/v5"
+)
+
+func (h *Inbound) UpdateUsers(users []option.TUICUser) error {
+	userList := make([]int, 0, len(users))
+	userNameList := make([]string, 0, len(users))
+	userUUIDList := make([][16]byte, 0, len(users))
+	userPasswordList := make([]string, 0, len(users))
+	for index, user := range users {
+		if user.UUID == "" {
+			return E.New("missing uuid for user ", index)
+		}
+		userUUID, err := uuid.FromString(user.UUID)
+		if err != nil {
+			return E.Cause(err, "invalid uuid for user ", index)
+		}
+		userList = append(userList, index)
+		userNameList = append(userNameList, user.Name)
+		userUUIDList = append(userUUIDList, userUUID)
+		userPasswordList = append(userPasswordList, user.Password)
+	}
+	h.server.UpdateUsers(userList, userUUIDList, userPasswordList)
+	h.userNameList = userNameList
+	return nil
+}

--- a/core/protocol/tuic/users.go
+++ b/core/protocol/tuic/users.go
@@ -25,6 +25,11 @@ func (h *Inbound) UpdateUsers(users []option.TUICUser) error {
 		userUUIDList = append(userUUIDList, userUUID)
 		userPasswordList = append(userPasswordList, user.Password)
 	}
+	// Grow before the server learns the new users, shrink after. See the
+	// comment in core/protocol/hysteria/users.go for why the order matters.
+	if len(userNameList) > len(h.userNameList) {
+		h.userNameList = userNameList
+	}
 	h.server.UpdateUsers(userList, userUUIDList, userPasswordList)
 	h.userNameList = userNameList
 	return nil

--- a/core/protocol/vless/inbound.go
+++ b/core/protocol/vless/inbound.go
@@ -1,0 +1,233 @@
+// Verbatim copy of sing-box v1.13.14 protocol/vless/inbound.go, moved into this
+// module so the panel can reach the unexported `service`/`users` fields that
+// the sing-box Inbound type does not expose. That access is what lets
+// core.UpdateInboundUsers swap an inbound's user table in place instead of
+// tearing the listener down (see core/inbound_users.go).
+//
+// UPGRADING sing-box: re-copy this file from the new tag and re-apply the
+// change below. Nothing here will fail to compile if you forget, it will just
+// silently keep running the old implementation.
+//
+// Local change vs sing-box: none, other than the package clause.
+package vless
+
+import (
+	"context"
+	"net"
+	"os"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/inbound"
+	"github.com/sagernet/sing-box/common/listener"
+	"github.com/sagernet/sing-box/common/mux"
+	"github.com/sagernet/sing-box/common/tls"
+	"github.com/sagernet/sing-box/common/uot"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/transport/v2ray"
+	"github.com/sagernet/sing-vmess/packetaddr"
+	"github.com/sagernet/sing-vmess/vless"
+	"github.com/sagernet/sing/common"
+	"github.com/sagernet/sing/common/auth"
+	"github.com/sagernet/sing/common/bufio"
+	E "github.com/sagernet/sing/common/exceptions"
+	F "github.com/sagernet/sing/common/format"
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+)
+
+func RegisterInbound(registry *inbound.Registry) {
+	inbound.Register[option.VLESSInboundOptions](registry, C.TypeVLESS, NewInbound)
+}
+
+var _ adapter.TCPInjectableInbound = (*Inbound)(nil)
+
+type Inbound struct {
+	inbound.Adapter
+	ctx       context.Context
+	router    adapter.ConnectionRouterEx
+	logger    logger.ContextLogger
+	listener  *listener.Listener
+	users     []option.VLESSUser
+	service   *vless.Service[int]
+	tlsConfig tls.ServerConfig
+	transport adapter.V2RayServerTransport
+}
+
+func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.VLESSInboundOptions) (adapter.Inbound, error) {
+	inbound := &Inbound{
+		Adapter: inbound.NewAdapter(C.TypeVLESS, tag),
+		ctx:     ctx,
+		router:  uot.NewRouter(router, logger),
+		logger:  logger,
+		users:   options.Users,
+	}
+	var err error
+	inbound.router, err = mux.NewRouterWithOptions(inbound.router, logger, common.PtrValueOrDefault(options.Multiplex))
+	if err != nil {
+		return nil, err
+	}
+	service := vless.NewService[int](logger, adapter.NewUpstreamContextHandlerEx(inbound.newConnectionEx, inbound.newPacketConnectionEx))
+	service.UpdateUsers(common.MapIndexed(inbound.users, func(index int, _ option.VLESSUser) int {
+		return index
+	}), common.Map(inbound.users, func(it option.VLESSUser) string {
+		return it.UUID
+	}), common.Map(inbound.users, func(it option.VLESSUser) string {
+		return it.Flow
+	}))
+	inbound.service = service
+	if options.TLS != nil {
+		inbound.tlsConfig, err = tls.NewServerWithOptions(tls.ServerOptions{
+			Context: ctx,
+			Logger:  logger,
+			Options: common.PtrValueOrDefault(options.TLS),
+			KTLSCompatible: common.PtrValueOrDefault(options.Transport).Type == "" &&
+				!common.PtrValueOrDefault(options.Multiplex).Enabled &&
+				common.All(options.Users, func(it option.VLESSUser) bool {
+					return it.Flow == ""
+				}),
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	if options.Transport != nil {
+		inbound.transport, err = v2ray.NewServerTransport(ctx, logger, common.PtrValueOrDefault(options.Transport), inbound.tlsConfig, (*inboundTransportHandler)(inbound))
+		if err != nil {
+			return nil, E.Cause(err, "create server transport: ", options.Transport.Type)
+		}
+	}
+	inbound.listener = listener.New(listener.Options{
+		Context:           ctx,
+		Logger:            logger,
+		Network:           []string{N.NetworkTCP},
+		Listen:            options.ListenOptions,
+		ConnectionHandler: inbound,
+	})
+	return inbound, nil
+}
+
+func (h *Inbound) Start(stage adapter.StartStage) error {
+	if stage != adapter.StartStateStart {
+		return nil
+	}
+	if h.tlsConfig != nil {
+		err := h.tlsConfig.Start()
+		if err != nil {
+			return err
+		}
+	}
+	if h.transport == nil {
+		return h.listener.Start()
+	}
+	if common.Contains(h.transport.Network(), N.NetworkTCP) {
+		tcpListener, err := h.listener.ListenTCP()
+		if err != nil {
+			return err
+		}
+		go func() {
+			sErr := h.transport.Serve(tcpListener)
+			if sErr != nil && !E.IsClosed(sErr) {
+				h.logger.Error("transport serve error: ", sErr)
+			}
+		}()
+	}
+	if common.Contains(h.transport.Network(), N.NetworkUDP) {
+		udpConn, err := h.listener.ListenUDP()
+		if err != nil {
+			return err
+		}
+		go func() {
+			sErr := h.transport.ServePacket(udpConn)
+			if sErr != nil && !E.IsClosed(sErr) {
+				h.logger.Error("transport serve error: ", sErr)
+			}
+		}()
+	}
+	return nil
+}
+
+func (h *Inbound) Close() error {
+	return common.Close(
+		h.service,
+		h.listener,
+		h.tlsConfig,
+		h.transport,
+	)
+}
+
+func (h *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	if h.tlsConfig != nil && h.transport == nil {
+		tlsConn, err := tls.ServerHandshake(ctx, conn, h.tlsConfig)
+		if err != nil {
+			N.CloseOnHandshakeFailure(conn, onClose, err)
+			h.logger.ErrorContext(ctx, E.Cause(err, "process connection from ", metadata.Source, ": TLS handshake"))
+			return
+		}
+		conn = tlsConn
+	}
+	err := h.service.NewConnection(adapter.WithContext(ctx, &metadata), conn, metadata.Source, onClose)
+	if err != nil {
+		N.CloseOnHandshakeFailure(conn, onClose, err)
+		h.logger.ErrorContext(ctx, E.Cause(err, "process connection from ", metadata.Source))
+	}
+}
+
+func (h *Inbound) newConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	userIndex, loaded := auth.UserFromContext[int](ctx)
+	if !loaded {
+		N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
+		return
+	}
+	user := h.users[userIndex].Name
+	if user == "" {
+		user = F.ToString(userIndex)
+	} else {
+		metadata.User = user
+	}
+	h.logger.InfoContext(ctx, "[", user, "] inbound connection to ", metadata.Destination)
+	h.router.RouteConnectionEx(ctx, conn, metadata, onClose)
+}
+
+func (h *Inbound) newPacketConnectionEx(ctx context.Context, conn N.PacketConn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	userIndex, loaded := auth.UserFromContext[int](ctx)
+	if !loaded {
+		N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
+		return
+	}
+	user := h.users[userIndex].Name
+	if user == "" {
+		user = F.ToString(userIndex)
+	} else {
+		metadata.User = user
+	}
+	if metadata.Destination.Fqdn == packetaddr.SeqPacketMagicAddress {
+		metadata.Destination = M.Socksaddr{}
+		conn = packetaddr.NewConn(bufio.NewNetPacketConn(conn), metadata.Destination)
+		h.logger.InfoContext(ctx, "[", user, "] inbound packet addr connection")
+	} else {
+		h.logger.InfoContext(ctx, "[", user, "] inbound packet connection to ", metadata.Destination)
+	}
+	h.router.RoutePacketConnectionEx(ctx, conn, metadata, onClose)
+}
+
+var _ adapter.V2RayServerTransportHandler = (*inboundTransportHandler)(nil)
+
+type inboundTransportHandler Inbound
+
+func (h *inboundTransportHandler) NewConnectionEx(ctx context.Context, conn net.Conn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
+	var metadata adapter.InboundContext
+	metadata.Source = source
+	metadata.Destination = destination
+	//nolint:staticcheck
+	metadata.InboundDetour = h.listener.ListenOptions().Detour
+	//nolint:staticcheck
+	h.logger.InfoContext(ctx, "inbound connection from ", metadata.Source)
+	(*Inbound)(h).NewConnectionEx(ctx, conn, metadata, onClose)
+}

--- a/core/protocol/vless/users.go
+++ b/core/protocol/vless/users.go
@@ -1,0 +1,18 @@
+package vless
+
+import (
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common"
+)
+
+func (h *Inbound) UpdateUsers(users []option.VLESSUser) error {
+	h.service.UpdateUsers(common.MapIndexed(users, func(index int, _ option.VLESSUser) int {
+		return index
+	}), common.Map(users, func(it option.VLESSUser) string {
+		return it.UUID
+	}), common.Map(users, func(it option.VLESSUser) string {
+		return it.Flow
+	}))
+	h.users = users
+	return nil
+}

--- a/core/protocol/vless/users.go
+++ b/core/protocol/vless/users.go
@@ -6,6 +6,11 @@ import (
 )
 
 func (h *Inbound) UpdateUsers(users []option.VLESSUser) error {
+	// Grow before the service learns the new users, shrink after. See the
+	// comment in core/protocol/hysteria/users.go for why the order matters.
+	if len(users) > len(h.users) {
+		h.users = users
+	}
 	h.service.UpdateUsers(common.MapIndexed(users, func(index int, _ option.VLESSUser) int {
 		return index
 	}), common.Map(users, func(it option.VLESSUser) string {

--- a/core/protocol/vmess/inbound.go
+++ b/core/protocol/vmess/inbound.go
@@ -1,0 +1,240 @@
+// Verbatim copy of sing-box v1.13.14 protocol/vmess/inbound.go, moved into this
+// module so the panel can reach the unexported `service`/`users` fields that
+// the sing-box Inbound type does not expose. That access is what lets
+// core.UpdateInboundUsers swap an inbound's user table in place instead of
+// tearing the listener down (see core/inbound_users.go).
+//
+// UPGRADING sing-box: re-copy this file from the new tag and re-apply the
+// change below. Nothing here will fail to compile if you forget, it will just
+// silently keep running the old implementation.
+//
+// Local change vs sing-box: the sing-vmess import is given an explicit `vmess`
+// alias, since this file's own package is also called vmess.
+package vmess
+
+import (
+	"context"
+	"net"
+	"os"
+
+	"github.com/sagernet/sing-box/adapter"
+	"github.com/sagernet/sing-box/adapter/inbound"
+	"github.com/sagernet/sing-box/common/listener"
+	"github.com/sagernet/sing-box/common/mux"
+	"github.com/sagernet/sing-box/common/tls"
+	"github.com/sagernet/sing-box/common/uot"
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/log"
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing-box/transport/v2ray"
+	vmess "github.com/sagernet/sing-vmess"
+	"github.com/sagernet/sing-vmess/packetaddr"
+	"github.com/sagernet/sing/common"
+	"github.com/sagernet/sing/common/auth"
+	"github.com/sagernet/sing/common/bufio"
+	E "github.com/sagernet/sing/common/exceptions"
+	F "github.com/sagernet/sing/common/format"
+	"github.com/sagernet/sing/common/logger"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+	"github.com/sagernet/sing/common/ntp"
+)
+
+func RegisterInbound(registry *inbound.Registry) {
+	inbound.Register[option.VMessInboundOptions](registry, C.TypeVMess, NewInbound)
+}
+
+var _ adapter.TCPInjectableInbound = (*Inbound)(nil)
+
+type Inbound struct {
+	inbound.Adapter
+	ctx       context.Context
+	router    adapter.ConnectionRouterEx
+	logger    logger.ContextLogger
+	listener  *listener.Listener
+	service   *vmess.Service[int]
+	users     []option.VMessUser
+	tlsConfig tls.ServerConfig
+	transport adapter.V2RayServerTransport
+}
+
+func NewInbound(ctx context.Context, router adapter.Router, logger log.ContextLogger, tag string, options option.VMessInboundOptions) (adapter.Inbound, error) {
+	inbound := &Inbound{
+		Adapter: inbound.NewAdapter(C.TypeVMess, tag),
+		ctx:     ctx,
+		router:  uot.NewRouter(router, logger),
+		logger:  logger,
+		users:   options.Users,
+	}
+	var err error
+	inbound.router, err = mux.NewRouterWithOptions(inbound.router, logger, common.PtrValueOrDefault(options.Multiplex))
+	if err != nil {
+		return nil, err
+	}
+	var serviceOptions []vmess.ServiceOption
+	if timeFunc := ntp.TimeFuncFromContext(ctx); timeFunc != nil {
+		serviceOptions = append(serviceOptions, vmess.ServiceWithTimeFunc(timeFunc))
+	}
+	if options.Transport != nil && options.Transport.Type != "" {
+		serviceOptions = append(serviceOptions, vmess.ServiceWithDisableHeaderProtection())
+	}
+	service := vmess.NewService[int](adapter.NewUpstreamContextHandlerEx(inbound.newConnectionEx, inbound.newPacketConnectionEx), serviceOptions...)
+	inbound.service = service
+	err = service.UpdateUsers(common.MapIndexed(options.Users, func(index int, it option.VMessUser) int {
+		return index
+	}), common.Map(options.Users, func(it option.VMessUser) string {
+		return it.UUID
+	}), common.Map(options.Users, func(it option.VMessUser) int {
+		return it.AlterId
+	}))
+	if err != nil {
+		return nil, err
+	}
+	if options.TLS != nil {
+		inbound.tlsConfig, err = tls.NewServer(ctx, logger, common.PtrValueOrDefault(options.TLS))
+		if err != nil {
+			return nil, err
+		}
+	}
+	if options.Transport != nil {
+		inbound.transport, err = v2ray.NewServerTransport(ctx, logger, common.PtrValueOrDefault(options.Transport), inbound.tlsConfig, (*inboundTransportHandler)(inbound))
+		if err != nil {
+			return nil, E.Cause(err, "create server transport: ", options.Transport.Type)
+		}
+	}
+	inbound.listener = listener.New(listener.Options{
+		Context:           ctx,
+		Logger:            logger,
+		Network:           []string{N.NetworkTCP},
+		Listen:            options.ListenOptions,
+		ConnectionHandler: inbound,
+	})
+	return inbound, nil
+}
+
+func (h *Inbound) Start(stage adapter.StartStage) error {
+	if stage != adapter.StartStateStart {
+		return nil
+	}
+	err := h.service.Start()
+	if err != nil {
+		return err
+	}
+	if h.tlsConfig != nil {
+		err = h.tlsConfig.Start()
+		if err != nil {
+			return err
+		}
+	}
+	if h.transport == nil {
+		return h.listener.Start()
+	}
+	if common.Contains(h.transport.Network(), N.NetworkTCP) {
+		tcpListener, err := h.listener.ListenTCP()
+		if err != nil {
+			return err
+		}
+		go func() {
+			sErr := h.transport.Serve(tcpListener)
+			if sErr != nil && !E.IsClosed(sErr) {
+				h.logger.Error("transport serve error: ", sErr)
+			}
+		}()
+	}
+	if common.Contains(h.transport.Network(), N.NetworkUDP) {
+		udpConn, err := h.listener.ListenUDP()
+		if err != nil {
+			return err
+		}
+		go func() {
+			sErr := h.transport.ServePacket(udpConn)
+			if sErr != nil && !E.IsClosed(sErr) {
+				h.logger.Error("transport serve error: ", sErr)
+			}
+		}()
+	}
+	return nil
+}
+
+func (h *Inbound) Close() error {
+	return common.Close(
+		h.service,
+		h.listener,
+		h.tlsConfig,
+		h.transport,
+	)
+}
+
+func (h *Inbound) NewConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	if h.tlsConfig != nil && h.transport == nil {
+		tlsConn, err := tls.ServerHandshake(ctx, conn, h.tlsConfig)
+		if err != nil {
+			N.CloseOnHandshakeFailure(conn, onClose, err)
+			h.logger.ErrorContext(ctx, E.Cause(err, "process connection from ", metadata.Source, ": TLS handshake"))
+			return
+		}
+		conn = tlsConn
+	}
+	err := h.service.NewConnection(adapter.WithContext(ctx, &metadata), conn, metadata.Source, onClose)
+	if err != nil {
+		N.CloseOnHandshakeFailure(conn, onClose, err)
+		h.logger.ErrorContext(ctx, E.Cause(err, "process connection from ", metadata.Source))
+	}
+}
+
+func (h *Inbound) newConnectionEx(ctx context.Context, conn net.Conn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	userIndex, loaded := auth.UserFromContext[int](ctx)
+	if !loaded {
+		N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
+		return
+	}
+	user := h.users[userIndex].Name
+	if user == "" {
+		user = F.ToString(userIndex)
+	} else {
+		metadata.User = user
+	}
+	h.logger.InfoContext(ctx, "[", user, "] inbound connection to ", metadata.Destination)
+	h.router.RouteConnectionEx(ctx, conn, metadata, onClose)
+}
+
+func (h *Inbound) newPacketConnectionEx(ctx context.Context, conn N.PacketConn, metadata adapter.InboundContext, onClose N.CloseHandlerFunc) {
+	metadata.Inbound = h.Tag()
+	metadata.InboundType = h.Type()
+	userIndex, loaded := auth.UserFromContext[int](ctx)
+	if !loaded {
+		N.CloseOnHandshakeFailure(conn, onClose, os.ErrInvalid)
+		return
+	}
+	user := h.users[userIndex].Name
+	if user == "" {
+		user = F.ToString(userIndex)
+	} else {
+		metadata.User = user
+	}
+	if metadata.Destination.Fqdn == packetaddr.SeqPacketMagicAddress {
+		metadata.Destination = M.Socksaddr{}
+		conn = packetaddr.NewConn(bufio.NewNetPacketConn(conn), metadata.Destination)
+		h.logger.InfoContext(ctx, "[", user, "] inbound packet addr connection")
+	} else {
+		h.logger.InfoContext(ctx, "[", user, "] inbound packet connection to ", metadata.Destination)
+	}
+	h.router.RoutePacketConnectionEx(ctx, conn, metadata, onClose)
+}
+
+var _ adapter.V2RayServerTransportHandler = (*inboundTransportHandler)(nil)
+
+type inboundTransportHandler Inbound
+
+func (h *inboundTransportHandler) NewConnectionEx(ctx context.Context, conn net.Conn, source M.Socksaddr, destination M.Socksaddr, onClose N.CloseHandlerFunc) {
+	var metadata adapter.InboundContext
+	metadata.Source = source
+	metadata.Destination = destination
+	//nolint:staticcheck
+	metadata.InboundDetour = h.listener.ListenOptions().Detour
+	//nolint:staticcheck
+	h.logger.InfoContext(ctx, "inbound connection from ", metadata.Source)
+	(*Inbound)(h).NewConnectionEx(ctx, conn, metadata, onClose)
+}

--- a/core/protocol/vmess/users.go
+++ b/core/protocol/vmess/users.go
@@ -1,0 +1,21 @@
+package vmess
+
+import (
+	"github.com/sagernet/sing-box/option"
+	"github.com/sagernet/sing/common"
+)
+
+func (h *Inbound) UpdateUsers(users []option.VMessUser) error {
+	err := h.service.UpdateUsers(common.MapIndexed(users, func(index int, _ option.VMessUser) int {
+		return index
+	}), common.Map(users, func(it option.VMessUser) string {
+		return it.UUID
+	}), common.Map(users, func(it option.VMessUser) int {
+		return it.AlterId
+	}))
+	if err != nil {
+		return err
+	}
+	h.users = users
+	return nil
+}

--- a/core/protocol/vmess/users.go
+++ b/core/protocol/vmess/users.go
@@ -6,6 +6,11 @@ import (
 )
 
 func (h *Inbound) UpdateUsers(users []option.VMessUser) error {
+	// Grow before the service learns the new users, shrink after. See the
+	// comment in core/protocol/hysteria/users.go for why the order matters.
+	if len(users) > len(h.users) {
+		h.users = users
+	}
 	err := h.service.UpdateUsers(common.MapIndexed(users, func(index int, _ option.VMessUser) int {
 		return index
 	}), common.Map(users, func(it option.VMessUser) string {

--- a/core/register.go
+++ b/core/register.go
@@ -1,6 +1,14 @@
 package core
 
 import (
+	suiAnytls "github.com/shenaba/2s-ui/core/protocol/anytls"
+	suiHysteria "github.com/shenaba/2s-ui/core/protocol/hysteria"
+	suiHysteria2 "github.com/shenaba/2s-ui/core/protocol/hysteria2"
+	suiTrojan "github.com/shenaba/2s-ui/core/protocol/trojan"
+	suiTuic "github.com/shenaba/2s-ui/core/protocol/tuic"
+	suiVless "github.com/shenaba/2s-ui/core/protocol/vless"
+	suiVmess "github.com/shenaba/2s-ui/core/protocol/vmess"
+
 	"github.com/sagernet/sing-box/adapter/endpoint"
 	"github.com/sagernet/sing-box/adapter/inbound"
 	"github.com/sagernet/sing-box/adapter/outbound"
@@ -54,16 +62,16 @@ func InboundRegistry() *inbound.Registry {
 	mixed.RegisterInbound(registry)
 
 	shadowsocks.RegisterInbound(registry)
-	vmess.RegisterInbound(registry)
-	trojan.RegisterInbound(registry)
+	suiVmess.RegisterInbound(registry)
+	suiTrojan.RegisterInbound(registry)
 	naive.RegisterInbound(registry)
 	shadowtls.RegisterInbound(registry)
-	vless.RegisterInbound(registry)
-	anytls.RegisterInbound(registry)
+	suiVless.RegisterInbound(registry)
+	suiAnytls.RegisterInbound(registry)
 
-	hysteria.RegisterInbound(registry)
-	tuic.RegisterInbound(registry)
-	hysteria2.RegisterInbound(registry)
+	suiHysteria.RegisterInbound(registry)
+	suiTuic.RegisterInbound(registry)
+	suiHysteria2.RegisterInbound(registry)
 
 	return registry
 }

--- a/core/tracker_conn.go
+++ b/core/tracker_conn.go
@@ -19,6 +19,7 @@ type ConnectionInfo struct {
 	Conn       net.Conn
 	PacketConn network.PacketConn
 	Inbound    string
+	User       string
 	Type       string // "tcp" or "udp"
 }
 
@@ -57,6 +58,7 @@ func (c *ConnTracker) RoutedConnection(ctx context.Context, conn net.Conn, metad
 		ID:      connID,
 		Conn:    conn,
 		Inbound: metadata.Inbound,
+		User:    metadata.User,
 		Type:    "tcp",
 	}
 
@@ -71,6 +73,7 @@ func (c *ConnTracker) RoutedPacketConnection(ctx context.Context, conn network.P
 		ID:         connID,
 		PacketConn: conn,
 		Inbound:    metadata.Inbound,
+		User:       metadata.User,
 		Type:       "udp",
 	}
 
@@ -95,6 +98,30 @@ func (c *ConnTracker) CloseConnByInbound(inbound string) int {
 			delete(c.connections, connID)
 			closedCount++
 		}
+	}
+	return closedCount
+}
+
+func (c *ConnTracker) CloseConnByInboundUsers(inbound string, keepUsers map[string]struct{}) int {
+	c.access.Lock()
+	defer c.access.Unlock()
+
+	closedCount := 0
+	for connID, connInfo := range c.connections {
+		if connInfo.Inbound != inbound {
+			continue
+		}
+		if _, keep := keepUsers[connInfo.User]; keep {
+			continue
+		}
+		if connInfo.Conn != nil {
+			connInfo.Conn.Close()
+		}
+		if connInfo.PacketConn != nil {
+			connInfo.PacketConn.Close()
+		}
+		delete(c.connections, connID)
+		closedCount++
 	}
 	return closedCount
 }

--- a/cronjob/depleteJob.go
+++ b/cronjob/depleteJob.go
@@ -23,11 +23,11 @@ func (s *DepleteJob) Run() {
 		return
 	}
 	if len(inboundIds) > 0 {
-		// RestartInbounds already filters to node_id IS NULL — only local
-		// inbounds are hot-restarted here.
-		err := s.InboundService.RestartInbounds(database.GetDB(), inboundIds)
+		// UpdateInboundsUsers already filters to node_id IS NULL — only local
+		// inbounds are touched here.
+		err := s.InboundService.UpdateInboundsUsers(database.GetDB(), inboundIds)
 		if err != nil {
-			logger.Error("unable to restart inbounds: ", err)
+			logger.Error("unable to update inbound users: ", err)
 		}
 	}
 	// Fan the disable out to nodes: reconcile sees enable=false in the expected

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/shenaba/2s-ui
 go 1.26.4
 
 require (
+	github.com/anytls/sing-anytls v0.0.11
 	github.com/caddyserver/certmagic v0.25.4
 	github.com/gin-contrib/gzip v1.2.6
 	github.com/gin-contrib/sessions v1.1.0
@@ -13,6 +14,8 @@ require (
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/sagernet/sing v0.8.11
 	github.com/sagernet/sing-box v1.13.14
+	github.com/sagernet/sing-quic v0.6.1
+	github.com/sagernet/sing-vmess v0.2.8-0.20250909125414-3aed155119a1
 	github.com/shirou/gopsutil/v4 v4.26.6
 	go.uber.org/zap v1.28.0
 	golang.org/x/crypto v0.54.0
@@ -29,7 +32,6 @@ require (
 	github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa // indirect
 	github.com/andybalholm/brotli v1.1.0 // indirect
 	github.com/anthropics/anthropic-sdk-go v1.26.0 // indirect
-	github.com/anytls/sing-anytls v0.0.11 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
@@ -143,12 +145,10 @@ require (
 	github.com/sagernet/nftables v0.3.0-mod.2 // indirect
 	github.com/sagernet/quic-go v0.59.0-sing-box-mod.4 // indirect
 	github.com/sagernet/sing-mux v0.3.5 // indirect
-	github.com/sagernet/sing-quic v0.6.1 // indirect
 	github.com/sagernet/sing-shadowsocks v0.2.8 // indirect
 	github.com/sagernet/sing-shadowsocks2 v0.2.1 // indirect
 	github.com/sagernet/sing-shadowtls v0.2.1-0.20250503051639-fcd445d33c11 // indirect
 	github.com/sagernet/sing-tun v0.8.11 // indirect
-	github.com/sagernet/sing-vmess v0.2.8-0.20250909125414-3aed155119a1 // indirect
 	github.com/sagernet/smux v1.5.50-sing-box-mod.1 // indirect
 	github.com/sagernet/tailscale v1.92.4-sing-box-1.13-mod.7 // indirect
 	github.com/sagernet/wireguard-go v0.0.2-beta.1.0.20260224074747-506b7631853c // indirect

--- a/scripts/check-protocol-copies.sh
+++ b/scripts/check-protocol-copies.sh
@@ -31,12 +31,14 @@ expect_diff() {
 }
 
 status=0
+checked=0
 for dir in core/protocol/*/; do
   proto=$(basename "$dir")
   local_file="$dir/inbound.go"
   upstream_file="$MODDIR/protocol/$proto/inbound.go"
 
   [ -f "$local_file" ] || continue
+  checked=$((checked + 1))
   if [ ! -f "$upstream_file" ]; then
     echo "  $proto: FAIL - no upstream counterpart at protocol/$proto/inbound.go"
     status=1
@@ -58,6 +60,13 @@ for dir in core/protocol/*/; do
     status=1
   fi
 done
+
+# An unmatched glob would run the loop zero times and exit 0, which reads as
+# "everything is in sync" when it actually means the check found nothing.
+if [ "$checked" -eq 0 ]; then
+  echo "no inbound.go found under core/protocol/ -- has the layout changed?" >&2
+  exit 1
+fi
 
 if [ "$status" -ne 0 ]; then
   echo

--- a/scripts/check-protocol-copies.sh
+++ b/scripts/check-protocol-copies.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# core/protocol/*/inbound.go are verbatim copies of sing-box's own inbound
+# implementations, forked only so that UpdateUsers can be attached to them
+# (see core/inbound_users.go). They will keep compiling after a sing-box bump
+# while silently running the old implementation, so this compares them against
+# the version currently in go.mod and fails on any drift.
+#
+# Run after bumping sing-box. If a file legitimately diverges, re-copy it from
+# the module cache and re-apply the local change, then update EXPECT_DIFF below.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+VERSION=$(go list -m -f '{{.Version}}' github.com/sagernet/sing-box)
+MODDIR=$(go list -m -f '{{.Dir}}' github.com/sagernet/sing-box)
+
+if [ ! -d "$MODDIR" ]; then
+  echo "sing-box module not in cache; run 'go mod download' first" >&2
+  exit 1
+fi
+
+echo "comparing core/protocol/*/inbound.go against sing-box $VERSION"
+
+# Lines each copy is expected to differ by, beyond the shared header comment:
+# vmess needs an explicit import alias because its own package is also `vmess`.
+expect_diff() {
+  case "$1" in
+    vmess) echo 2 ;;
+    *) echo 0 ;;
+  esac
+}
+
+status=0
+for dir in core/protocol/*/; do
+  proto=$(basename "$dir")
+  local_file="$dir/inbound.go"
+  upstream_file="$MODDIR/protocol/$proto/inbound.go"
+
+  [ -f "$local_file" ] || continue
+  if [ ! -f "$upstream_file" ]; then
+    echo "  $proto: FAIL - no upstream counterpart at protocol/$proto/inbound.go"
+    status=1
+    continue
+  fi
+
+  # Drop the local header comment block: everything before the package clause.
+  actual=$(diff <(sed -n '/^package /,$p' "$local_file") \
+                <(sed -n '/^package /,$p' "$upstream_file") \
+             | grep -c '^[<>]' || true)
+  expected=$(expect_diff "$proto")
+
+  if [ "$actual" -eq "$expected" ]; then
+    echo "  $proto: ok"
+  else
+    echo "  $proto: DRIFT - $actual differing lines, expected $expected"
+    diff <(sed -n '/^package /,$p' "$local_file") \
+         <(sed -n '/^package /,$p' "$upstream_file") | sed 's/^/      /' || true
+    status=1
+  fi
+done
+
+if [ "$status" -ne 0 ]; then
+  echo
+  echo "The copies no longer match sing-box $VERSION." >&2
+  echo "Re-copy from $MODDIR/protocol/<proto>/inbound.go and re-apply local changes." >&2
+fi
+exit "$status"

--- a/service/config.go
+++ b/service/config.go
@@ -224,7 +224,7 @@ func (s *ConfigService) Save(obj string, act string, data json.RawMessage, initU
 		inboundIds, err = s.ClientService.Save(tx, act, data, hostname)
 		if err == nil && len(inboundIds) > 0 {
 			objs = append(objs, "inbounds")
-			err = s.InboundService.RestartInbounds(tx, inboundIds)
+			err = s.InboundService.UpdateInboundsUsers(tx, inboundIds)
 			if err != nil {
 				return nil, common.NewErrorf("failed to update users for inbounds: %v", err)
 			}

--- a/service/inbounds.go
+++ b/service/inbounds.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/shenaba/2s-ui/database"
 	"github.com/shenaba/2s-ui/database/model"
+	"github.com/shenaba/2s-ui/logger"
 	"github.com/shenaba/2s-ui/util"
 	"github.com/shenaba/2s-ui/util/common"
 
@@ -365,6 +366,73 @@ func (s *InboundService) initUsers(db *gorm.DB, inboundJson []byte, clientIds st
 	}
 
 	return json.Marshal(inbound)
+}
+
+func (s *InboundService) enabledClientNames(tx *gorm.DB, inboundId uint) (map[string]struct{}, error) {
+	var names []string
+	err := tx.Raw(
+		"SELECT clients.name FROM clients, json_each(clients.inbounds) AS je WHERE je.value = ? AND clients.enable = true",
+		inboundId).Scan(&names).Error
+	if err != nil {
+		return nil, err
+	}
+	keep := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		keep[name] = struct{}{}
+	}
+	return keep, nil
+}
+
+func (s *InboundService) UpdateInboundsUsers(tx *gorm.DB, ids []uint) error {
+	if !corePtr.IsRunning() {
+		return nil
+	}
+	var inbounds []*model.Inbound
+	// Same filter as RestartInbounds: a client edit passes in the union of its
+	// inbound ids, which may include node replicas. Those are not in the local
+	// core, so the fallback below would AddInbound them here and bind the remote
+	// node's port locally.
+	err := tx.Model(model.Inbound{}).Preload("Tls").Where("id in ?", ids).Where("node_id IS NULL").Find(&inbounds).Error
+	if err != nil {
+		return err
+	}
+	for _, inbound := range inbounds {
+		inboundConfig, err := inbound.MarshalJSON()
+		if err != nil {
+			return err
+		}
+		inboundConfig, err = s.addUsers(tx, inboundConfig, inbound.Id, inbound.Type)
+		if err != nil {
+			return err
+		}
+
+		handled, err := corePtr.UpdateInboundUsers(inboundConfig)
+		if err != nil {
+			return err
+		}
+		if handled {
+			// Disconnect only users no longer enabled on this inbound
+			keep, err := s.enabledClientNames(tx, inbound.Id)
+			if err != nil {
+				return err
+			}
+			closed := corePtr.GetInstance().ConnTracker().CloseConnByInboundUsers(inbound.Tag, keep)
+			logger.Debug("updated users of inbound ", inbound.Tag, " in place, closed ", closed, " stale connections")
+			continue
+		}
+
+		// Fallback: full restart for protocols without in-place user updates
+		err = corePtr.RemoveInbound(inbound.Tag)
+		if err != nil && err != os.ErrInvalid {
+			return err
+		}
+		corePtr.GetInstance().ConnTracker().CloseConnByInbound(inbound.Tag)
+		err = corePtr.AddInbound(inboundConfig)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (s *InboundService) RestartInbounds(tx *gorm.DB, ids []uint) error {

--- a/service/inbounds.go
+++ b/service/inbounds.go
@@ -406,12 +406,22 @@ func (s *InboundService) UpdateInboundsUsers(tx *gorm.DB, ids []uint) error {
 			return err
 		}
 
+		// An in-place update that errors leaves the inbound running with its old
+		// user table, so a removed user would stay connected and keep
+		// authenticating. Fall through to the restart rather than returning:
+		// dropping every connection on this inbound is the safe failure.
 		handled, err := corePtr.UpdateInboundUsers(inboundConfig)
 		if err != nil {
-			return err
+			logger.Warning("in-place user update failed for inbound ", inbound.Tag, ", restarting it: ", err)
+			handled = false
 		}
 		if handled {
-			// Disconnect only users no longer enabled on this inbound
+			// Disconnect only users no longer enabled on this inbound.
+			//
+			// Matching is by user name, so rotating a client's UUID or password
+			// does NOT drop its live connection -- the name is unchanged, so it
+			// stays in `keep` and the old credential keeps working until the
+			// connection ends on its own. Tracked separately; see issue.
 			keep, err := s.enabledClientNames(tx, inbound.Id)
 			if err != nil {
 				return err


### PR DESCRIPTION
Ports upstream `2be943e`. **Needs testing on a real box before merge — see below.**

## The problem

Every client edit, and every cron-driven quota depletion, went through `RestartInbounds`, which removes the inbound from the core and adds it back. For the QUIC-based protocols that also destroys the QUIC session and its authentication state, so **changing one user dropped every connected user on that inbound**. Upstream tracks this as #1136 / #1085.

## The mechanism

sing-box keeps an inbound's user table in unexported fields and its `Inbound` types do not surface `UpdateUsers`. The underlying services (`*vless.Service`, `*vmess.Service`, …) *do* have it — it just is not reachable from outside the sing-box package.

So seven protocol inbounds (anytls, hysteria, hysteria2, trojan, tuic, vless, vmess) are copied into `core/protocol/` to make that access possible, and `Core.UpdateInboundUsers` dispatches on the inbound option type. Shadowsocks is not copied — sing-box already exports `MultiInbound.UpdateUsers`.

Anything unrecognised returns `handled=false`, so the caller falls back to the old full restart. Certificate changes (`service/tls.go`) keep using `RestartInbounds` on purpose: a new certificate does need the listener rebuilt.

`ConnTracker` now records `metadata.User` per connection and gains `CloseConnByInboundUsers`, so only the users that actually lost access get disconnected.

## Divergence from upstream

Upstream's `UpdateInboundsUsers` filters on `id in ?` only. **This branch adds `node_id IS NULL`**, matching `RestartInbounds`. A client edit passes in the union of its inbound ids, which may include node replicas; those are not in the local core, so they would miss the in-place path, hit the fallback, and `AddInbound` them here — binding the remote node's port locally and wedging the core in its 15s restart loop. Upstream has no node concept so it never had to care.

## Maintenance cost, please read

`core/protocol/*/inbound.go` are **verbatim copies of sing-box v1.13.14 source**. I verified this: six are byte-identical to the module cache, vmess differs only by an explicit `vmess` import alias. Each file carries a header saying so.

They will keep compiling after a sing-box bump while silently running the old implementation. Re-aligning them is now a manual step of every sing-box upgrade.

`go mod tidy` promotes sing-anytls, sing-quic and sing-vmess from indirect to direct. No version changes; go.sum untouched.

## Verification — incomplete

`go vet ./...` and `go build -checklinkname=0` are clean. That is all.

The actual payoff (users staying connected across a change) is **not verified**. The repo has no tests and this needs a real deployment with QUIC clients to confirm. The `node_id IS NULL` guard is likewise reasoned from the existing code path, not exercised against a multi-node setup.

Suggest running this on a test panel with a hysteria2 or tuic inbound and a couple of live clients, editing an unrelated user, and confirming the others stay up.