### PR TITLE
Port upstream v1.5.4 frontend features

### DIFF
--- a/api/apiService.go
+++ b/api/apiService.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"runtime"
 	"strconv"
 	"time"
 
@@ -134,6 +135,7 @@ func (a *ApiService) getData(c *gin.Context) (interface{}, error) {
 		data["nodes"] = nodes
 		data["subURI"] = subURI
 		data["enableTraffic"] = trafficAge > 0
+		data["os"] = runtime.GOOS
 		data["onlines"] = onlines
 	} else {
 		data["onlines"] = onlines

--- a/frontend/src/components/forms/out/protocols/Hysteria.vue
+++ b/frontend/src/components/forms/out/protocols/Hysteria.vue
@@ -9,6 +9,7 @@
       <div style="display: flex; flex-direction: column; gap: 2px; padding: 4px;">
         <div class="pop-item"><SwitchLabel v-model="optionRsvConn" label="Recv window conn" /></div>
         <div class="pop-item"><SwitchLabel v-model="optionRsvWin" label="Recv window" /></div>
+        <div class="pop-item"><SwitchLabel v-model="optionMPort" :label="$t('rule.portRange')" /></div>
       </div>
     </Pop>
   </div>
@@ -33,6 +34,14 @@
       <input class="input mono" type="number" min="0" v-model.number="data.recv_window" />
     </Field>
   </div>
+  <template v-if="optionMPort">
+    <Field :label="$t('rule.portRange') + ' ' + $t('commaSeparated')">
+      <input class="input mono" v-model="serverPorts" />
+    </Field>
+    <Field :label="$t('ruleset.interval') + ' (' + $t('date.s') + ')'">
+      <input class="input mono" type="number" min="0" v-model.number="hopInterval" />
+    </Field>
+  </template>
   <div style="margin-bottom: 15px;">
     <SwitchLabel v-model="disableMtu" label="Disable MTU discovery" />
   </div>
@@ -60,6 +69,18 @@ const optionRsvConn = computed({
 const optionRsvWin = computed({
   get: (): boolean => props.data.recv_window != undefined,
   set: (v: boolean) => { props.data.recv_window = v ? 67108864 : undefined },
+})
+const optionMPort = computed({
+  get: (): boolean => props.data.server_ports != undefined,
+  set: (v: boolean) => { props.data.server_ports = v ? [] : undefined },
+})
+const serverPorts = computed({
+  get: () => props.data.server_ports?.join(',') ?? '',
+  set: (v: string) => { props.data.server_ports = v.length > 0 ? v.split(',') : undefined },
+})
+const hopInterval = computed({
+  get: () => props.data.hop_interval ? parseInt(props.data.hop_interval.replace('s', '')) : 0,
+  set: (v: number) => { props.data.hop_interval = v > 0 ? v + 's' : undefined },
 })
 const downMbps = computed({
   get: () => props.data.down_mbps ? props.data.down_mbps : 0,

--- a/frontend/src/layouts/drawers/tls/TlsDrawer.vue
+++ b/frontend/src/layouts/drawers/tls/TlsDrawer.vue
@@ -165,8 +165,10 @@
 
     <!-- ===================== ACME ===================== -->
     <!-- Hidden on a Windows server: sing-box's built-in ACME does not work
-         there, and offering it silently does nothing (upstream #1189). -->
-    <template v-if="!isWindows">
+         there, and offering it silently does nothing (upstream #1189).
+         An entry that already has ACME configured still shows the section, or
+         it would be invisible and impossible to turn off from the panel. -->
+    <template v-if="!isWindows || acmeEnabled">
       <MSwitchRow v-model="acmeEnabled" :label="$t('ui.acmeTitle')" :desc="$t('ui.acmeDesc')" />
       <Acme :tls="inTls" />
     </template>

--- a/frontend/src/layouts/drawers/tls/TlsDrawer.vue
+++ b/frontend/src/layouts/drawers/tls/TlsDrawer.vue
@@ -164,8 +164,12 @@
     <hr class="form-divider" />
 
     <!-- ===================== ACME ===================== -->
-    <MSwitchRow v-model="acmeEnabled" :label="$t('ui.acmeTitle')" :desc="$t('ui.acmeDesc')" />
-    <Acme :tls="inTls" />
+    <!-- Hidden on a Windows server: sing-box's built-in ACME does not work
+         there, and offering it silently does nothing (upstream #1189). -->
+    <template v-if="!isWindows">
+      <MSwitchRow v-model="acmeEnabled" :label="$t('ui.acmeTitle')" :desc="$t('ui.acmeDesc')" />
+      <Acme :tls="inTls" />
+    </template>
 
     <!-- ===================== ECH ===================== -->
     <MSwitchRow v-model="echEnabled" :label="$t('ui.echTitle')" :desc="$t('ui.echDesc')" />
@@ -500,6 +504,7 @@ const optionTime = computed({
 })
 
 // ---------------- ACME / ECH section toggles ----------------
+const isWindows = computed((): boolean => Data().os === 'windows')
 const acmeEnabled = computed({
   get: (): boolean => inTls.value.acme != undefined,
   set: (v: boolean) => { inTls.value.acme = v ? { domain: [] } : undefined },

--- a/frontend/src/store/modules/data.ts
+++ b/frontend/src/store/modules/data.ts
@@ -11,6 +11,7 @@ const Data = defineStore('Data', {
     lastLoad: 0,
     reloadItems: localStorage.getItem("reloadItems")?.split(',')?? <string[]>[],
     subURI: "",
+    os: "",
     enableTraffic: false,
     onlines: {inbound: <string[]>[], outbound: <string[]>[], user: <string[]>[]},
     config: <any>{},
@@ -47,6 +48,7 @@ const Data = defineStore('Data', {
     setNewData(data: any) {
       this.lastLoad = Math.floor((new Date()).getTime()/1000)
       if (data.subURI) this.subURI = data.subURI
+      if (data.os) this.os = data.os
       if (data.enableTraffic) this.enableTraffic = data.enableTraffic
       if (data.config) this.config = data.config
       if (Object.hasOwn(data, 'clients')) this.clients = data.clients ?? []

--- a/frontend/src/types/outbounds.ts
+++ b/frontend/src/types/outbounds.ts
@@ -121,6 +121,8 @@ export interface Naive extends OutboundBasics, Dial {
 export interface Hysteria extends OutboundBasics, Dial {
   server: string
   server_port: number
+  server_ports?: string[]
+  hop_interval?: string
   up_mbps: number
   down_mbps: number
   obfs?: string

--- a/frontend/src/views/Clients.vue
+++ b/frontend/src/views/Clients.vue
@@ -125,7 +125,14 @@
                 <span v-else style="color: var(--text-3); font-size: 13px;">—</span>
               </td>
               <td class="actions-td">
-                <div style="display: flex; gap: 2px; justify-content: flex-end;" @click.stop>
+                <div style="display: flex; gap: 2px; justify-content: flex-end; align-items: center;" @click.stop>
+                  <Toggle
+                    :model-value="c.enable"
+                    :scale="0.8"
+                    :title="$t(c.enable ? 'disable' : 'enable')"
+                    style="margin-inline-end: 4px;"
+                    @update:model-value="toggleEnable(c)"
+                  />
                   <IconBtn name="qr" :title="$t('client.links')" @click="showQrCode(c.id)" />
                   <IconBtn v-if="dataStore.enableTraffic" name="chart" :title="$t('stats.graphTitle')" @click="showStats(c.name)" />
                   <IconBtn name="edit" :title="$t('actions.edit')" @click="openDrawer(c.id)" />
@@ -194,6 +201,13 @@
           </span>
         </div>
         <div class="m-actions" @click.stop>
+          <Toggle
+            :model-value="c.enable"
+            :scale="0.8"
+            :title="$t(c.enable ? 'disable' : 'enable')"
+            style="margin-inline-end: 4px;"
+            @update:model-value="toggleEnable(c)"
+          />
           <IconBtn name="qr" :title="$t('client.links')" @click="showQrCode(c.id)" />
           <IconBtn v-if="dataStore.enableTraffic" name="chart" :title="$t('stats.graphTitle')" @click="showStats(c.name)" />
           <IconBtn name="edit" :title="$t('actions.edit')" @click="openDrawer(c.id)" />
@@ -228,6 +242,7 @@ import Chip from '@/components/ui/Chip.vue'
 import Check from '@/components/ui/Check.vue'
 import Avatar from '@/components/ui/Avatar.vue'
 import IconBtn from '@/components/ui/IconBtn.vue'
+import Toggle from '@/components/ui/Toggle.vue'
 import Segmented from '@/components/ui/Segmented.vue'
 import Modal from '@/components/ui/Modal.vue'
 import BarMini from '@/components/charts/BarMini.vue'
@@ -357,6 +372,25 @@ const protoSummary = (c: any): string => {
   return types.length > 0 ? types.join(', ') : '—'
 }
 const inbTitle = (c: any): string => inboundsOf(c).map((i: any) => i.tag).join('\n')
+
+// ---------------- quick enable / disable ----------------
+// The list rows are a projection, so the full client has to be fetched before
+// saving or the unprojected fields would be written back as empty.
+const toggling = ref<Record<number, boolean>>({})
+
+const toggleEnable = async (c: any) => {
+  if (toggling.value[c.id]) return
+  toggling.value = { ...toggling.value, [c.id]: true }
+  try {
+    const full = await Data().loadClients(c.id)
+    if (full?.id) {
+      full.enable = !c.enable
+      await Data().save('clients', 'edit', full)
+    }
+  } finally {
+    toggling.value = { ...toggling.value, [c.id]: false }
+  }
+}
 
 // ---------------- drawers / modals ----------------
 const drawer = ref({ visible: false, id: 0 })

--- a/frontend/src/views/Endpoints.vue
+++ b/frontend/src/views/Endpoints.vue
@@ -30,6 +30,14 @@
       <Btn variant="primary" sm @click="openDrawer(0)">
         <Ico name="plus" :size="15" /> {{ $t('actions.add') }}
       </Btn>
+      <Btn
+        sm
+        :loading="testingAll"
+        :disabled="testingAll || endpoints.length === 0"
+        @click="checkAllEndpoints"
+      >
+        <Ico name="chart" :size="15" /> {{ $t('actions.testAll') }}
+      </Btn>
     </div>
 
     <div class="entity-grid">
@@ -48,6 +56,13 @@
         </template>
         <template #actions>
           <CardBtn icon="edit" :title="$t('actions.edit')" @click="openDrawer(item.id)" />
+          <CardBtn
+            icon="bolt"
+            border
+            :title="$t('ui.delay')"
+            :disabled="checkResults[item.tag]?.loading"
+            @click="checkEndpoint(item.tag)"
+          />
           <CardBtn icon="trash" border danger :title="$t('actions.del')" @click="askDelete(item.tag)" />
           <CardBtn
             v-if="item.type == 'wireguard' && item.peers?.length > 0"
@@ -73,6 +88,7 @@
 import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import Data from '@/store/modules/data'
+import HttpUtils from '@/plugins/httputil'
 import { Endpoint } from '@/types/endpoints'
 import Btn from '@/components/ui/Btn.vue'
 import Ico from '@/components/ui/Ico.vue'
@@ -97,6 +113,42 @@ const onlines = computed(() => [
   ...dataStore.onlines.outbound ?? [],
 ])
 
+// ---------------- delay check ----------------
+// Endpoints register as outbounds in the core, so the same api/checkOutbound
+// latency probe used on the Outbounds page works here unchanged.
+interface CheckResult {
+  loading?: boolean
+  success: boolean
+  data?: { OK?: boolean; Delay?: number; Error?: string } | null
+  errorMessage?: string
+}
+
+const checkResults = ref<Record<string, CheckResult>>({})
+
+const checkEndpoint = async (tag: string) => {
+  checkResults.value = { ...checkResults.value, [tag]: { loading: true, success: false } }
+  const msg = await HttpUtils.get('api/checkOutbound', { tag })
+  const success = msg.success && msg.obj?.OK
+  const errorMessage = success ? undefined : (msg.obj?.Error ?? msg.msg ?? '')
+  checkResults.value = {
+    ...checkResults.value,
+    [tag]: { loading: false, success, data: msg.obj ?? null, errorMessage },
+  }
+}
+
+const testingAll = ref(false)
+
+const checkAllEndpoints = async () => {
+  const list = endpoints.value
+  if (list.length === 0) return
+  testingAll.value = true
+  try {
+    await Promise.all(list.map((e) => checkEndpoint(e.tag)))
+  } finally {
+    testingAll.value = false
+  }
+}
+
 // ---------------- card rows ----------------
 const cardRows = (item: any): EntityRow[] => [
   {
@@ -110,7 +162,20 @@ const cardRows = (item: any): EntityRow[] => [
     mono: item.listen_port > 0,
   },
   { k: t('types.wg.peers'), v: item.peers?.length ?? t('ui.none') },
+  delayRow(item),
 ]
+
+const delayRow = (item: any): EntityRow => {
+  const r = checkResults.value[item.tag]
+  if (r?.loading) return { k: t('out.delay'), v: '…', mono: true }
+  if (r && r.loading == false) {
+    if (r.success) {
+      return { k: t('out.delay'), v: (r.data?.Delay ?? 0) + ' ' + t('date.ms'), mono: true, color: 'var(--emerald)' }
+    }
+    return { k: t('out.delay'), v: r.errorMessage || t('failed'), color: 'var(--rose)' }
+  }
+  return { k: t('out.delay'), v: t('ui.none') }
+}
 
 // ---------------- drawers / modals ----------------
 const drawer = ref({ visible: false, id: 0, data: '' })


### PR DESCRIPTION
Ports the five frontend changes from upstream's v1.5.4 (`alireza0/s-ui-frontend` `d2b56b7..69b02bc`), plus the one backend line one of them needs. Upstream is Vuetify, so all of this is reimplemented against our own primitives rather than copied.

## What is added

- **Server OS is reported** (`cec2d6e` + `3eee6af`) — `api/load` now carries `runtime.GOOS`; the store keeps it as `os`. The TLS drawer uses it to hide the ACME section on a Windows server.
- **Hysteria v1 outbound port hopping** (`680b1b5`) — `server_ports` / `hop_interval` were already editable for Hysteria2 and on the inbound's client-side JSON, but not here.
- **Quick enable/disable on the Clients list** (`26db382`) — a toggle in the row actions, on both the table and the mobile card. The handler re-fetches the full client before saving, since the list rows are a projection and writing one back directly would blank every unprojected field.
- **Endpoint latency test** (`83e5093`) — endpoints register as outbounds in the core, so `api/checkOutbound` works on them unchanged. Mirrors the Outbounds page: per-card probe, a delay row, and "Test all".

## The one judgement call

Hiding ACME on Windows rests on **upstream's assertion**, not on my own verification. Their issue #1189 says sing-box's built-in ACME is non-functional on the Windows build and the maintainer confirmed it, but both of our Windows build paths do pass `with_acme`, so I could not work out *why* it fails.

It is consistent with how the rest of the panel already treats Windows (`service/acme.go`'s nginx detection and `web.go`'s nginx mode are both GOOS-gated), which is why I went ahead. If you know it actually works, revert `c7ab396` on its own — nothing else depends on it.

## Verification

`go vet`, `go build -checklinkname=0`, `vue-tsc --noEmit` and `npm run build` all clean.

Every item was driven in a browser with no console errors:
- Hysteria v1: the Port Ranges option appears in the menu and reveals both fields.
- Clients: toggles render and track `enable` (checked/unchecked, `on` class).
- Endpoints: the Delay row renders on the card.
- ACME: visible at `os=''`, gone at `os='windows'`, ECH unaffected.
- No raw i18n keys leaked into any of the new labels.

Not verified: the toggle's save round-trip and the endpoint probe's response handling, both of which need a live backend — the dev mock adapter does not exercise them.