### PR TITLE
chore: group dependabot updates and pin actions by SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,32 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      # Every gomod PR rewrites go.mod and go.sum, so concurrent ones always
+      # conflict and all but the first need a rebase. Batch them into one.
+      gomod:
+        patterns:
+          - "*"
+        # sing-box stays ungrouped. Bumping it makes the verbatim copies in
+        # core/protocol/ go stale, so scripts/check-protocol-copies.sh fails
+        # and every copy has to be re-taken from the module cache. That work
+        # does not belong in a PR that also moves unrelated dependencies.
+        exclude-patterns:
+          - "github.com/sagernet/sing-box"
+        update-types:
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
   # Carried over from the frontend repo when it was inlined. Without this entry
   # the frontend's npm deps simply stop being updated -- the gomod entry above
   # does not cover them, and the frontend repo's own config no longer applies.
@@ -15,3 +37,22 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
+    groups:
+      frontend:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    # typescript is the one major dependabot can never land here on its own:
+    # typescript-eslint pins `typescript >=4.8.4 <6.1.0` and has not moved as
+    # of 8.65.0, so the typescript 7 bump could not even get past install.
+    #
+    # Kept to that single package on purpose. `ignore` suppresses security
+    # update PRs as well as version ones, and most of these dependencies ship
+    # inside the SPA, so a blanket major ignore would silence exactly the
+    # updates worth hearing about.
+    ignore:
+      - dependency-name: "typescript"
+        update-types:
+          - "version-update:semver-major"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
       # builds it: web/html is gitignored, and web.go's `//go:embed *` matches
       # web.go itself, so the embed resolves without a frontend build.
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
           cache: true
@@ -77,10 +77,10 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 25
       - name: Install dependencies and build frontend
@@ -25,7 +25,7 @@ jobs:
           npm install
           npm run build
       - name: Upload frontend build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend-dist
           path: frontend/dist/
@@ -44,9 +44,9 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Download frontend build artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: frontend-dist
           path: frontend_dist
@@ -56,7 +56,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ghcr.io/shenaba/2s-ui
@@ -66,30 +66,30 @@ jobs:
             type=ref,event=tag
             type=pep440,pattern={{version}}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Cache Docker layers
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ matrix.platform }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-${{ matrix.platform }}-
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           username: shenaba
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: Dockerfile.frontend-artifact
@@ -107,7 +107,7 @@ jobs:
           digest="${{ steps.build.outputs.digest }}"
           echo "${digest#sha256:}" > "${{ runner.temp }}/digests/${digest#sha256:}"
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*
@@ -119,27 +119,27 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
           merge-multiple: true
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Login to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           username: shenaba
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: |
             ghcr.io/shenaba/2s-ui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (frontend only)
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
@@ -49,7 +49,7 @@ jobs:
           cd ..
 
       - name: Upload frontend dist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend-dist
           path: frontend/dist/
@@ -80,16 +80,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download frontend dist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: frontend-dist
           path: web/html
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           cache: false
           go-version-file: go.mod
@@ -116,7 +116,7 @@ jobs:
       - name: Cache Chromium toolchain
         if: matrix.naive
         id: cache-chromium-toolchain
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |
             ~/cronet-go/naiveproxy/src/third_party/llvm-build/
@@ -206,14 +206,14 @@ jobs:
         run: tar -zcvf s-ui-linux-${{ matrix.platform }}.tar.gz s-ui
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: s-ui-linux-${{ matrix.platform }}
           path: ./s-ui-linux-${{ matrix.platform }}.tar.gz
           retention-days: 30
 
       - name: Upload to Release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         if: |
           github.event_name == 'release' && github.event.action == 'published'
         with:
@@ -234,7 +234,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all release tarballs
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: s-ui-linux-*
           merge-multiple: true
@@ -243,7 +243,7 @@ jobs:
         run: sha256sum s-ui-linux-*.tar.gz | tee SHA256SUMS
 
       - name: Upload SHA256SUMS to Release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.event.release.tag_name }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,12 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
@@ -46,7 +46,7 @@ jobs:
           cd ..
 
       - name: Upload frontend artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: frontend-dist
           path: frontend/dist
@@ -64,16 +64,16 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download frontend artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: frontend-dist
           path: web/html
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           cache: false
           go-version-file: go.mod
@@ -107,14 +107,14 @@ jobs:
           Compress-Archive -Path s-ui-windows -DestinationPath "s-ui-windows-${{ matrix.arch }}.zip"
 
       - name: Upload files to Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: s-ui-windows-${{ matrix.arch }}
           path: ./s-ui-windows-${{ matrix.arch }}.zip
           retention-days: 30
 
       - name: Upload to Release
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # 2.11.5
         if: |
           github.event_name == 'release' && github.event.action == 'published'
         with:


### PR DESCRIPTION
Two independent changes to how dependencies are proposed and how actions are resolved. Neither touches application code.

## 1. `chore(deps)` — group dependabot updates, hold back typescript 7

Nine dependabot PRs were open at once, four of them single-package npm patches. Every gomod PR rewrites `go.mod`/`go.sum` and every npm PR rewrites the lockfile, so concurrent ones always conflict and all but the first need a rebase.

- Minor and patch updates are now batched into **one PR per ecosystem** (`gomod`, `github-actions`, `frontend`). Majors still get their own PR.
- **`sing-box` is excluded from the gomod group.** Bumping it makes the verbatim copies in `core/protocol/` go stale, `scripts/check-protocol-copies.sh` fails, and every copy has to be re-taken from the module cache. That work does not belong in a PR that also moves unrelated dependencies.
- **`typescript` majors are ignored** — and only `typescript`. `typescript-eslint` pins `typescript >=4.8.4 <6.1.0` and has not moved as of 8.65.0, which is why #50 could not even get past install. No other major is blocked: `ignore` suppresses **security** update PRs as well as version ones, and most frontend dependencies ship inside the SPA, so a blanket major ignore would silence exactly the updates worth hearing about.

`ignore` is deliberately absent from gomod and github-actions for the same reason. A Go major changes the import path, so dependabot cannot propose one anyway; and an ignored action major means workflows silently rot on a deprecated runner runtime.

## 2. `ci` — pin every action to a commit SHA

`actions/checkout` was the only action pinned to a full patch version; every other action floated on a major tag. Both forms resolve through a mutable ref, and these workflows produce the binaries users download and run as root, so a repointed tag would land straight in the release artifact. `svenstaro/upload-release-action@v2` is the clearest case: a moving tag, the only third-party action, and it handles release asset upload directly.

All 12 actions, 41 `uses:` lines across the 4 workflows:

| Action | Before | After |
|---|---|---|
| actions/checkout | `@v7.0.0` | `3d3c42e5…` # v7.0.1 |
| actions/setup-go | `@v7` | `b7ad1dad…` # v7.0.0 |
| actions/setup-node | `@v7` | `82076278…` # v7.0.0 |
| actions/upload-artifact | `@v7` | `043fb46d…` # v7.0.1 |
| actions/download-artifact | `@v8` | `3e5f45b2…` # v8.0.1 |
| actions/cache | `@v6` | `55cc8345…` # v6.1.0 |
| docker/build-push-action | `@v7` | `53b7df96…` # v7.3.0 |
| docker/login-action | `@v4` | `abd2ef45…` # v4.5.1 |
| docker/metadata-action | `@v6` | `dc802804…` # v6.2.0 |
| docker/setup-buildx-action | `@v4` | `bb05f3f5…` # v4.2.0 |
| docker/setup-qemu-action | `@v4` | `96fe6ef7…` # v4.2.0 |
| svenstaro/upload-release-action | `@v2` | `29e53e91…` # 2.11.5 |

Each SHA is the newest tag within the major already in use, and each floating ref was confirmed to resolve to that same commit today — so **nothing changes behaviourally except checkout**, which moves 7.0.0 → 7.0.1.

Trade-off worth naming: a SHA pin no longer picks up an action's own patch releases automatically, so a security fix in e.g. `actions/checkout` now waits for a dependabot PR rather than arriving on the next run.

## Effect on the open dependabot PRs

- **#63** (checkout 7.0.1) is superseded by the pin — can be closed.
- **#50** (typescript 7) is now ignored — dependabot will close it.
- **#54 / #56 / #57 / #58** will be replaced by one `frontend` group PR.
- **#64 / #65 / #70** will be replaced by one `gomod` group PR, which also resolves the go.mod conflicts between them.

## Verification

- Every one of the 12 SHAs was re-resolved through `gh api repos/OWNER/REPO/commits/TAG` and matched what is written in the files.
- Each floating `@vN` was compared against the newest patch tag in that major; all 10 matched, which is what backs the "no behaviour change" claim above.
- All 4 workflows re-parsed after the rewrite, job structure intact. No `uses: …@v<n>` references remain, and there are no composite actions.
- `ci.yml` is the only PR-triggered workflow and it only exercises checkout / setup-go / setup-node, so `release.yml` and `windows.yml` were additionally run via `workflow_dispatch` on this branch. Their release-upload steps are gated on `github.event_name == 'release'`, so those runs publish nothing.
- **Not verified:** `docker.yml` (it pushes public images to GHCR and Docker Hub even on a dispatch, so it was not run) and the `svenstaro/upload-release-action` pin (its steps are skipped outside a real release). `docker.yml` also has no `push` trigger, so merging will not exercise it either — it stays untested until a release is cut.
- The dependabot config's schema can only be confirmed on GitHub's side, under Insights → Dependency graph → Dependabot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
