### PR TITLE
ci: collapse redundant release and windows builds with concurrency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,16 @@ on:
       - 'go.sum'
       - 's-ui.service'
 
+# Merging several PRs in a row queues one full matrix per push, and only the last
+# one builds the tree that ships. github.ref already separates a release run
+# (refs/tags/...) from a push run, and the cancel guard is belt-and-braces: a
+# publish must never be cancelled part-way through uploading its assets. The
+# group name has to stay distinct from windows.yml's, or the two would cancel
+# each other.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
+
 permissions:
   contents: write
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,6 +15,13 @@ on:
       - 'go.sum'
       - 'windows/**'
 
+# Same reasoning as release.yml: collapse the redundant push builds, never cancel
+# a publish. The group name has to stay distinct from release.yml's, or the two
+# workflows would cancel each other.
+concurrency:
+  group: windows-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
+
 permissions:
   contents: write
 


### PR DESCRIPTION
Adds a `concurrency` group to `release.yml` and `windows.yml`. 17 lines, no other change.

## Why

Merging #71, #73, #72 and #70 back to back today queued **four** seven-platform release matrices and **four** windows matrices against `main`. Only the last of each built the tree that ships — the rest built intermediate commits nobody will ever download.

`ci.yml` already had a group and behaved correctly through the same sequence:

```
06:39:10  CI                       completed/cancelled   <- superseded, cancelled
06:39:10  Release 2S-UI            completed/success     <- ran the full matrix anyway
06:39:10  Build 2S-UI for Windows  completed/success     <- ran the full matrix anyway
06:39:13  CI                       completed/success
06:39:13  Release 2S-UI            completed/success
06:39:13  Build 2S-UI for Windows  completed/success
```

These two workflows simply never got one.

## The change

```yaml
concurrency:
  group: release-${{ github.ref }}          # windows-… in windows.yml
  cancel-in-progress: ${{ github.event_name != 'release' }}
```

Two details that are load-bearing:

- **`cancel-in-progress` is guarded on the event, not a bare `true`.** `github.ref` already puts a release run (`refs/tags/…`) in a different group from a push run (`refs/heads/main`), so the guard is belt-and-braces — but getting this wrong means cancelling a publish part-way through uploading its assets and shipping a release with only some platforms present. Worth the extra expression.
- **The two group names are deliberately different.** A shared name would make the release and windows workflows cancel *each other* on every push to main.

Placement matches `ci.yml`: between `on:` and `permissions:`.

## Verification

- All three workflows re-parse; job structure intact. The three group names (`ci-`, `release-`, `windows-`) are distinct.
- `cancel-in-progress` resolves to `false` under a `release` event, which is the case that matters.
- **Not verified, and not verifiable here:** neither workflow responds to `pull_request`, so CI cannot exercise this. Concurrency behaviour also only shows up under genuinely concurrent triggers — a single `workflow_dispatch` would prove the syntax parses and the workflow still starts, nothing more. The real check is the next time two PRs merge in quick succession: the earlier `Release 2S-UI` run should come back `cancelled`, the way `CI` already does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
