### PR TITLE
fix(sub): stop emitting node replica outbounds twice

### DIFF
--- a/sub/clashService.go
+++ b/sub/clashService.go
@@ -77,6 +77,7 @@ func (s *ClashService) GetClash(subId string) (*string, []string, error) {
 	extOutbounds, extTags := s.LinkService.GetExternalOutbounds(&client.Links)
 	*outbounds = append(*outbounds, extOutbounds...)
 	*outTags = append(*outTags, extTags...)
+	uniqueOutboundTags(*outbounds, *outTags)
 
 	basicConfig, err := s.getClashConfig()
 	if err != nil || len(basicConfig) == 0 {

--- a/sub/clashService.go
+++ b/sub/clashService.go
@@ -425,6 +425,16 @@ func buildProxyGroups(output map[string]interface{}, proxyTags []string, noDefGr
 			defaultGroups = defaultGroups[:1]
 			defaultGroups[0]["proxies"] = proxyTags
 		}
+		// No routes at all — e.g. the client only references node replicas and
+		// reconciliation has not written their links yet. A url-test group with
+		// an empty proxies list fails mihomo's config parse outright, taking
+		// the whole subscription with it (the Clash twin of the empty urltest
+		// the JSON path degrades around). Drop Auto and point Proxy at the
+		// built-in DIRECT so the profile still imports.
+		if len(proxyTags) == 0 {
+			defaultGroups = defaultGroups[:1]
+			defaultGroups[0]["proxies"] = []string{"DIRECT"}
+		}
 	}
 	// noDefGrp leaves defaultGroups nil, so this is the custom groups alone.
 	proxyGroups := mergeProxyGroups(defaultGroups, customGroups)

--- a/sub/jsonService.go
+++ b/sub/jsonService.go
@@ -64,6 +64,7 @@ func (j *JsonService) GetJson(subId string, format string) (*string, []string, e
 	extOutbounds, extTags := j.LinkService.GetExternalOutbounds(&client.Links)
 	*outbounds = append(*outbounds, extOutbounds...)
 	*outTags = append(*outTags, extTags...)
+	uniqueOutboundTags(*outbounds, *outTags, defaultOutboundTags...)
 
 	j.addDefaultOutbounds(outbounds, outTags)
 
@@ -99,7 +100,13 @@ func (j *JsonService) getData(subId string) (*model.Client, []*model.Inbound, er
 		return nil, nil, err
 	}
 	var inbounds []*model.Inbound
-	err = db.Model(model.Inbound{}).Preload("Tls").Where("id in ?", clientInbounds).Find(&inbounds).Error
+	// node_id IS NULL: a replica's route already reaches the subscription as the
+	// "[node] " external link refreshNodeLinks folds into client.Links. Building
+	// an outbound from the replica row too emits the same tag twice, which
+	// sing-box and mihomo both reject outright — and that second copy is the
+	// broken one, since adoption clears tls_id and getOutbounds then drops flow.
+	// service/client.go applies the same filter for the plain link subscription.
+	err = db.Model(model.Inbound{}).Preload("Tls").Where("id in ? and node_id IS NULL", clientInbounds).Find(&inbounds).Error
 	if err != nil {
 		return nil, nil, err
 	}
@@ -232,7 +239,66 @@ func (j *JsonService) getOutbounds(clientConfig json.RawMessage, inbounds []*mod
 	return &outbounds, &outTags, nil
 }
 
+// defaultOutboundTags are the tags addDefaultOutbounds injects. They are taken
+// before any route is named, so uniqueOutboundTags has to reserve them.
+var defaultOutboundTags = []string{"proxy", "auto", "direct"}
+
+// uniqueOutboundTags renames duplicate tags in place, across every source that
+// feeds the outbound list. A collision has to degrade to a renamed route: both
+// sing-box and mihomo reject the *whole* config on a duplicate tag, so leaving
+// one in place costs the user the entire subscription, not one route.
+//
+// reserved holds names the caller injects after this runs — a route colliding
+// with one of those is just as fatal as two routes colliding with each other.
+//
+// Must run before the tags are used to build the selector/urltest groups, or
+// those groups reference names no outbound carries.
+func uniqueOutboundTags(outbounds []map[string]interface{}, tags []string, reserved ...string) {
+	seen := make(map[string]struct{}, len(tags)+len(reserved))
+	for _, tag := range reserved {
+		seen[tag] = struct{}{}
+	}
+	for i, base := range tags {
+		tag := base
+		// Loop rather than a per-base counter: the generated "tag-2" may itself
+		// collide with a tag that was already there.
+		for n := 2; ; n++ {
+			if _, dup := seen[tag]; !dup {
+				break
+			}
+			tag = fmt.Sprintf("%s-%d", base, n)
+		}
+		seen[tag] = struct{}{}
+		tags[i] = tag
+		if i < len(outbounds) {
+			outbounds[i]["tag"] = tag
+		}
+	}
+}
+
 func (j *JsonService) addDefaultOutbounds(outbounds *[]map[string]interface{}, outTags *[]string) {
+	direct := map[string]interface{}{
+		"type": "direct",
+		"tag":  "direct",
+	}
+
+	// No routes at all — e.g. the client only references node replicas and
+	// reconciliation has not yet written their "[node] " links. urltest would
+	// have nothing to probe, and a nil outTags even marshals to `null`, which
+	// makes sing-box reject the whole config. Ship a selector over direct so the
+	// profile still imports.
+	if len(*outTags) == 0 {
+		*outbounds = append([]map[string]interface{}{
+			{
+				"outbounds": []string{"direct"},
+				"tag":       "proxy",
+				"type":      "selector",
+			},
+			direct,
+		}, *outbounds...)
+		return
+	}
+
 	outbound := []map[string]interface{}{
 		{
 			"outbounds": append([]string{"auto", "direct"}, *outTags...),
@@ -242,15 +308,13 @@ func (j *JsonService) addDefaultOutbounds(outbounds *[]map[string]interface{}, o
 		{
 			"tag":       "auto",
 			"type":      "urltest",
-			"outbounds": outTags,
+			// Deref: a *[]string would marshal to null when the slice is nil.
+			"outbounds": *outTags,
 			"url":       "http://www.gstatic.com/generate_204",
 			"interval":  "10m",
 			"tolerance": 50,
 		},
-		{
-			"type": "direct",
-			"tag":  "direct",
-		},
+		direct,
 	}
 	*outbounds = append(outbound, *outbounds...)
 }

--- a/sub/jsonService_test.go
+++ b/sub/jsonService_test.go
@@ -1,0 +1,326 @@
+package sub
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shenaba/2s-ui/database"
+	"github.com/shenaba/2s-ui/database/model"
+)
+
+// setupSubDB gives each test its own sqlite file. The connection has to be
+// closed explicitly: there is no database.CloseDB, and on Windows t.TempDir's
+// cleanup fails to remove a file that is still open.
+func setupSubDB(t *testing.T) {
+	t.Helper()
+	if err := database.InitDB(filepath.Join(t.TempDir(), "s-ui.db")); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := database.GetDB().DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+}
+
+const (
+	replicaOutJson = `{"type":"vless","tag":"vless-node","server":"jp.example.com","server_port":16600,` +
+		`"tls":{"enabled":true,"reality":{"enabled":true,"public_key":"pk","short_id":"a1"},` +
+		`"server_name":"www.cloudflare.com","utls":{"enabled":true,"fingerprint":"chrome"}},"transport":{}}`
+
+	// What refreshNodeLinks folds into client.Links for that replica.
+	replicaLink = `vless://5bdbac27-7a82-42c5-9ef4-751f64bd15e4@jp.example.com:16600` +
+		`?security=reality&pbk=pk&sid=a1&sni=www.cloudflare.com&fp=chrome&flow=xtls-rprx-vision#vless-node`
+
+	clientVlessConfig = `{"vless":{"uuid":"5bdbac27-7a82-42c5-9ef4-751f64bd15e4","flow":"xtls-rprx-vision"}}`
+)
+
+// seedNodeReplicaClient reproduces the state the panel reaches after adopting a
+// node inbound and binding a client to it: a replica row (node_id set, tls_id
+// cleared by adoption) plus the "[node] " external link reconciliation writes.
+func seedNodeReplicaClient(t *testing.T, subId string) {
+	t.Helper()
+	db := database.GetDB()
+
+	nodeId := uint(1)
+	replica := &model.Inbound{
+		Type:    "vless",
+		Tag:     "vless-node",
+		NodeId:  &nodeId,
+		Addrs:   json.RawMessage(`[]`),
+		OutJson: json.RawMessage(replicaOutJson),
+		Options: json.RawMessage(`{}`),
+	}
+	if err := db.Create(replica).Error; err != nil {
+		t.Fatalf("seed replica: %v", err)
+	}
+
+	links := fmt.Sprintf(`[{"remark":"[jp2] vless-node","type":"external","uri":%q}]`, replicaLink)
+	client := &model.Client{
+		Enable:   true,
+		Name:     subId,
+		Config:   json.RawMessage(clientVlessConfig),
+		Inbounds: json.RawMessage(fmt.Sprintf(`[%d]`, replica.Id)),
+		Links:    json.RawMessage(links),
+	}
+	if err := db.Create(client).Error; err != nil {
+		t.Fatalf("seed client: %v", err)
+	}
+}
+
+func outboundsOf(t *testing.T, raw string) []map[string]interface{} {
+	t.Helper()
+	var cfg map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	list, ok := cfg["outbounds"].([]interface{})
+	if !ok {
+		t.Fatalf("config has no outbounds array: %s", raw)
+	}
+	out := make([]map[string]interface{}, 0, len(list))
+	for _, item := range list {
+		if m, ok := item.(map[string]interface{}); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// A client bound to a node replica must get that route exactly once. The replica
+// row and the "[node] " external link describe the same route, and emitting both
+// makes sing-box reject the whole config with "duplicate outbound tag".
+func TestGetJson_NodeReplicaEmittedOnce(t *testing.T) {
+	setupSubDB(t)
+	seedNodeReplicaClient(t, "subnode")
+
+	raw, _, err := (&JsonService{}).GetJson("subnode", "json")
+	if err != nil {
+		t.Fatalf("GetJson: %v", err)
+	}
+
+	// Count by type, not by tag: the tag-uniqueness backstop would rename a
+	// second copy to "vless-node-2" and a tag-only assertion would miss it.
+	var matched []map[string]interface{}
+	routes := 0
+	for _, ob := range outboundsOf(t, *raw) {
+		if ob["type"] == "vless" {
+			routes++
+		}
+		if ob["tag"] == "vless-node" {
+			matched = append(matched, ob)
+		}
+	}
+	if routes != 1 {
+		t.Fatalf("node route emitted %d times, want 1:\n%s", routes, *raw)
+	}
+	if len(matched) != 1 {
+		t.Fatalf("vless-node emitted %d times, want 1:\n%s", len(matched), *raw)
+	}
+	// The surviving copy must be the link-derived one. The replica row loses
+	// flow (adoption clears tls_id), and reality without vision cannot connect.
+	if matched[0]["flow"] != "xtls-rprx-vision" {
+		t.Fatalf("surviving outbound must keep flow, got %v", matched[0]["flow"])
+	}
+
+	// The groups must reference it once too, or urltest probes the same route twice.
+	for _, ob := range outboundsOf(t, *raw) {
+		tag, _ := ob["tag"].(string)
+		if tag != "proxy" && tag != "auto" {
+			continue
+		}
+		refs, _ := ob["outbounds"].([]interface{})
+		count := 0
+		for _, r := range refs {
+			if r == "vless-node" {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Fatalf("group %q references vless-node %d times, want 1", tag, count)
+		}
+	}
+}
+
+// Clash shares getData/getOutbounds with the JSON subscription, and mihomo
+// rejects a config with a duplicate proxy name just as sing-box does.
+func TestGetClash_NodeReplicaEmittedOnce(t *testing.T) {
+	setupSubDB(t)
+	seedNodeReplicaClient(t, "subnode")
+
+	raw, _, err := (&ClashService{}).GetClash("subnode")
+	if err != nil {
+		t.Fatalf("GetClash: %v", err)
+	}
+	if got := strings.Count(*raw, "name: vless-node"); got != 1 {
+		t.Fatalf("proxy name emitted %d times, want 1:\n%s", got, *raw)
+	}
+}
+
+// Filtering the replica out can leave a client with no routes at all — it only
+// references node inbounds and reconciliation has not written their links yet.
+// The config still has to import: urltest with an empty (or null) outbounds list
+// is rejected outright, which is worse than the duplicate this fix removed.
+func TestGetJson_NoRoutesStillImports(t *testing.T) {
+	setupSubDB(t)
+	db := database.GetDB()
+
+	nodeId := uint(1)
+	replica := &model.Inbound{
+		Type: "vless", Tag: "vless-node", NodeId: &nodeId,
+		Addrs:   json.RawMessage(`[]`),
+		OutJson: json.RawMessage(replicaOutJson),
+		Options: json.RawMessage(`{}`),
+	}
+	if err := db.Create(replica).Error; err != nil {
+		t.Fatalf("seed replica: %v", err)
+	}
+	client := &model.Client{
+		Enable: true, Name: "subempty",
+		Config:   json.RawMessage(clientVlessConfig),
+		Inbounds: json.RawMessage(fmt.Sprintf(`[%d]`, replica.Id)),
+		Links:    json.RawMessage(`[]`), // reconcile has not run
+	}
+	if err := db.Create(client).Error; err != nil {
+		t.Fatalf("seed client: %v", err)
+	}
+
+	raw, _, err := (&JsonService{}).GetJson("subempty", "json")
+	if err != nil {
+		t.Fatalf("GetJson: %v", err)
+	}
+	// A literal null is what a *[]string over a nil slice produces — assert on
+	// the text too, since a decoded nil and an empty list look alike in Go.
+	if strings.Contains(*raw, `"outbounds": null`) {
+		t.Fatalf("no outbounds list may serialise to null:\n%s", *raw)
+	}
+	for _, ob := range outboundsOf(t, *raw) {
+		if ob["type"] == "urltest" {
+			t.Fatalf("urltest must not be emitted with no routes to probe:\n%s", *raw)
+		}
+		if ob["tag"] == "proxy" {
+			refs, _ := ob["outbounds"].([]interface{})
+			if len(refs) == 0 {
+				t.Fatalf("proxy selector must offer at least direct:\n%s", *raw)
+			}
+			for _, r := range refs {
+				if r == "auto" {
+					t.Fatalf("proxy must not reference the absent urltest:\n%s", *raw)
+				}
+			}
+		}
+	}
+}
+
+// The default proxy/auto/direct tags are injected after the routes are named, so
+// a route carrying one of those names collides with them just as fatally as two
+// routes colliding with each other.
+func TestGetJson_TagCollidingWithDefaultIsRenamed(t *testing.T) {
+	setupSubDB(t)
+	db := database.GetDB()
+
+	local := &model.Inbound{
+		Type: "vless", Tag: "direct",
+		Addrs:   json.RawMessage(`[]`),
+		OutJson: json.RawMessage(`{"type":"vless","tag":"direct","server":"1.2.3.4","server_port":443,"transport":{}}`),
+		Options: json.RawMessage(`{}`),
+	}
+	if err := db.Create(local).Error; err != nil {
+		t.Fatalf("seed local inbound: %v", err)
+	}
+	client := &model.Client{
+		Enable: true, Name: "subdefault",
+		Config:   json.RawMessage(clientVlessConfig),
+		Inbounds: json.RawMessage(fmt.Sprintf(`[%d]`, local.Id)),
+		Links:    json.RawMessage(`[]`),
+	}
+	if err := db.Create(client).Error; err != nil {
+		t.Fatalf("seed client: %v", err)
+	}
+
+	raw, _, err := (&JsonService{}).GetJson("subdefault", "json")
+	if err != nil {
+		t.Fatalf("GetJson: %v", err)
+	}
+	seen := map[string]int{}
+	for _, ob := range outboundsOf(t, *raw) {
+		if tag, ok := ob["tag"].(string); ok {
+			seen[tag]++
+		}
+	}
+	for tag, n := range seen {
+		if n > 1 {
+			t.Fatalf("tag %q emitted %d times:\n%s", tag, n, *raw)
+		}
+	}
+	// The route yields, the injected default keeps the name.
+	if seen["direct-2"] != 1 {
+		t.Fatalf("colliding route must be renamed to direct-2, got tags %v", seen)
+	}
+}
+
+// Backstop: a tag can still collide from sources the replica filter does not
+// cover — here a hand-added external link whose fragment matches a local
+// inbound's tag. That must degrade to a renamed route, never to a config the
+// client refuses wholesale.
+func TestGetJson_CollidingExternalLinkIsRenamed(t *testing.T) {
+	setupSubDB(t)
+	db := database.GetDB()
+
+	local := &model.Inbound{
+		Type:    "vless",
+		Tag:     "HK",
+		Addrs:   json.RawMessage(`[]`),
+		OutJson: json.RawMessage(`{"type":"vless","tag":"HK","server":"1.2.3.4","server_port":443,"transport":{}}`),
+		Options: json.RawMessage(`{}`),
+	}
+	if err := db.Create(local).Error; err != nil {
+		t.Fatalf("seed local inbound: %v", err)
+	}
+
+	// Two external links: one collides with the local tag, one already carries a
+	// "-1" suffix. That second one is the point of the case — a renamer that
+	// hands out "-1" for the first collision (as the old links-only dedup did)
+	// produces two "HK-1" here and the subscription is rejected anyway.
+	links := `[
+		{"remark":"pasted","type":"external","uri":"vless://aaaaaaaa-0000-4000-8000-000000000001@5.6.7.8:443?security=tls#HK"},
+		{"remark":"pasted","type":"external","uri":"vless://aaaaaaaa-0000-4000-8000-000000000002@9.10.11.12:443?security=tls#HK-1"}
+	]`
+	client := &model.Client{
+		Enable:   true,
+		Name:     "subcollide",
+		Config:   json.RawMessage(clientVlessConfig),
+		Inbounds: json.RawMessage(fmt.Sprintf(`[%d]`, local.Id)),
+		Links:    json.RawMessage(links),
+	}
+	if err := db.Create(client).Error; err != nil {
+		t.Fatalf("seed client: %v", err)
+	}
+
+	raw, _, err := (&JsonService{}).GetJson("subcollide", "json")
+	if err != nil {
+		t.Fatalf("GetJson: %v", err)
+	}
+
+	seen := map[string]int{}
+	for _, ob := range outboundsOf(t, *raw) {
+		if tag, ok := ob["tag"].(string); ok {
+			seen[tag]++
+		}
+	}
+	for tag, n := range seen {
+		if n > 1 {
+			t.Fatalf("tag %q emitted %d times, every tag must be unique:\n%s", tag, n, *raw)
+		}
+	}
+	// All three routes survive, and the renamed one skips past the pre-existing
+	// HK-1 rather than colliding with it.
+	for _, want := range []string{"HK", "HK-1", "HK-2"} {
+		if seen[want] != 1 {
+			t.Fatalf("expected tag %q exactly once, got %d (tags: %v)", want, seen[want], seen)
+		}
+	}
+}

--- a/sub/jsonService_test.go
+++ b/sub/jsonService_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/shenaba/2s-ui/database"
 	"github.com/shenaba/2s-ui/database/model"
+
+	"gopkg.in/yaml.v3"
 )
 
 // setupSubDB gives each test its own sqlite file. The connection has to be
@@ -212,6 +214,71 @@ func TestGetJson_NoRoutesStillImports(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+// Clash twin of TestGetJson_NoRoutesStillImports: a url-test group whose
+// proxies list is empty fails mihomo's config parse just as an empty urltest
+// fails sing-box's, so the default groups have to degrade — no Auto, and the
+// Proxy selector falling back to the built-in DIRECT.
+func TestGetClash_NoRoutesStillImports(t *testing.T) {
+	setupSubDB(t)
+	db := database.GetDB()
+
+	nodeId := uint(1)
+	replica := &model.Inbound{
+		Type: "vless", Tag: "vless-node", NodeId: &nodeId,
+		Addrs:   json.RawMessage(`[]`),
+		OutJson: json.RawMessage(replicaOutJson),
+		Options: json.RawMessage(`{}`),
+	}
+	if err := db.Create(replica).Error; err != nil {
+		t.Fatalf("seed replica: %v", err)
+	}
+	client := &model.Client{
+		Enable: true, Name: "subclashempty",
+		Config:   json.RawMessage(clientVlessConfig),
+		Inbounds: json.RawMessage(fmt.Sprintf(`[%d]`, replica.Id)),
+		Links:    json.RawMessage(`[]`), // reconcile has not run
+	}
+	if err := db.Create(client).Error; err != nil {
+		t.Fatalf("seed client: %v", err)
+	}
+
+	raw, _, err := (&ClashService{}).GetClash("subclashempty")
+	if err != nil {
+		t.Fatalf("GetClash: %v", err)
+	}
+
+	var cfg map[string]interface{}
+	if err := yaml.Unmarshal([]byte(*raw), &cfg); err != nil {
+		t.Fatalf("unmarshal clash yaml: %v", err)
+	}
+	groups, _ := cfg["proxy-groups"].([]interface{})
+	if len(groups) == 0 {
+		t.Fatalf("default groups must still be injected:\n%s", *raw)
+	}
+	var proxyGroup map[string]interface{}
+	for _, g := range groups {
+		gm, _ := g.(map[string]interface{})
+		if gm == nil {
+			continue
+		}
+		if gm["name"] == "Auto" {
+			t.Fatalf("Auto must not be emitted with no routes to probe:\n%s", *raw)
+		}
+		if proxies, _ := gm["proxies"].([]interface{}); len(proxies) == 0 {
+			t.Fatalf("group %v has an empty proxies list, which mihomo rejects:\n%s", gm["name"], *raw)
+		}
+		if gm["name"] == "Proxy" {
+			proxyGroup = gm
+		}
+	}
+	if proxyGroup == nil {
+		t.Fatalf("Proxy group missing:\n%s", *raw)
+	}
+	if proxies, _ := proxyGroup["proxies"].([]interface{}); len(proxies) != 1 || proxies[0] != "DIRECT" {
+		t.Fatalf("Proxy must fall back to the built-in DIRECT alone, got %v", proxies)
 	}
 }
 

--- a/sub/linkService.go
+++ b/sub/linkService.go
@@ -2,7 +2,6 @@ package sub
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/shenaba/2s-ui/logger"
@@ -74,19 +73,9 @@ func (s *LinkService) GetExternalOutbounds(linkJson *json.RawMessage) ([]map[str
 		}
 	}
 
-	// Make tags unique; sing-box and clash reject duplicate tags/names.
-	seen := make(map[string]int)
-	for i, tag := range tags {
-		if n := seen[tag]; n > 0 {
-			newTag := fmt.Sprintf("%s-%d", tag, n)
-			seen[tag] = n + 1
-			tags[i] = newTag
-			outbounds[i]["tag"] = newTag
-		} else {
-			seen[tag] = 1
-		}
-	}
-
+	// Tag uniqueness is settled by uniqueOutboundTags once every source has been
+	// merged: deduping only within the links here left collisions against the
+	// inbound-derived tags unnoticed.
 	return outbounds, tags
 }
 


### PR DESCRIPTION
Refs #89.

## Problem

A client bound to an adopted node inbound gets that route into the JSON and Clash subscriptions **twice**, under the same tag. sing-box refuses the whole config (`decode config: duplicate outbound/endpoint tag: vless-31570`) and mihomo rejects a duplicate proxy name the same way, so the subscription cannot be imported at all.

Affects **v1.6.0 – v1.6.3**, master panel only. The plain link subscription is unaffected.

## Root cause

A replica's route is meant to reach the subscription through exactly one path: on each reconcile, `refreshNodeLinks` regenerates a share link from the replica's node-side `out_json` snapshot and folds it into `client.Links` as a `[node] ` external entry.

`sub/jsonService.go`'s `getData` was *also* selecting replicas and building an outbound straight from the replica row. `service/client.go` already avoids exactly this for the plain link subscription with a `node_id IS NULL` filter — the subscription generators simply never got the same filter. `ed430d4`, which added the external-link path, only touched `service/nodeSync.go`.

The extra copy was also the broken one: adoption clears `tls_id`, and `getOutbounds` only copies `flow` when `tls_id` is set, so a reality + `xtls-rprx-vision` route came out without `flow` and could not connect even if a client tolerated the duplicate name.

## Changes

- `getData` filters out replicas (`node_id IS NULL`), matching `service/client.go`. One change fixes both `?format=json` and `?format=clash`, since `ClashService` embeds `JsonService`.
- Tag uniqueness now runs across **every** source feeding the outbound list. `GetExternalOutbounds` deduped only within the links and never compared against inbound-derived tags, so this collision slipped past it — as would a hand-added external link whose fragment matches a local inbound tag, which has nothing to do with nodes. The replacement loops until the name is free; the old counter handed out `tag-1` for a first collision and silently produced a duplicate when a `tag-1` already existed.
- The injected `proxy`/`auto`/`direct` tags are reserved up front. They are added after the routes are named, so a route called `direct` collided with the injected direct outbound just as fatally.
- Filtering replicas out can leave a client with no routes at all (it only references node inbounds and reconciliation has not written their links yet). urltest then had nothing to probe, and a nil tag slice behind a pointer marshalled to `"outbounds": null`, which sing-box refuses — worse than the duplicate being removed. With no routes the config now ships a selector over `direct` alone and no urltest.
- The same no-routes case hit Clash too: the default `Auto` url-test group came out with an empty `proxies` list, which fails mihomo's config parse just as fatally. With no routes the default groups now degrade to the `Proxy` selector over the built-in `DIRECT`, and no `Auto`.

## Verification

Six tests in `sub/jsonService_test.go`, using a real sqlite database per test. Each was checked by reverting the corresponding fix and confirming it fails:

| Test | Reverting |
|---|---|
| `TestGetJson_NodeReplicaEmittedOnce` | drop the `node_id` filter → fails |
| `TestGetClash_NodeReplicaEmittedOnce` | drop the `node_id` filter → fails |
| `TestGetJson_CollidingExternalLinkIsRenamed` | drop the cross-source dedup → fails |
| `TestGetJson_TagCollidingWithDefaultIsRenamed` | stop reserving default tags → fails |
| `TestGetJson_NoRoutesStillImports` | restore the always-urltest path → fails with `"outbounds": null` |
| `TestGetClash_NoRoutesStillImports` | restore the unconditional `Auto` group → fails |

Also verified end to end on a real master + node deployment: adopted a node inbound, bound a client to it, and confirmed the tag appeared twice in both `?format=json` and `?format=clash` (including the `proxy`/`auto` groups) before the fix and once after, with the surviving copy being the link-derived one. A client bound only to local inbounds produced a byte-identical subscription before and after.

`go vet` and `go build` pass with the CI tag set.

## Not included

Clash's default group names (`Proxy`/`Auto`/`DIRECT`) are not reserved: they differ in case from route tags and are conditional on the `noDefGrp` setting, and that path was not tested here.
