### PR TITLE
ci: run go test in the backend job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ name: CI
 # trigger at all, so a Dockerfile change stays ungated until a release.)
 #
 # Both jobs run on every PR rather than behind path filters. A Go-only PR pays a
-# vite build and an npm-only PR pays a Go build, which is a minute each and buys
-# the simpler thing: no filter to drift out of sync, and no skipped job to confuse
-# a required status check.
+# vite build and an npm-only PR pays a Go build plus tests, which is a few
+# minutes each and buys the simpler thing: no filter to drift out of sync, and no
+# skipped job to confuse a required status check.
 on:
   pull_request:
   push:
@@ -33,7 +33,7 @@ jobs:
     env:
       # Same tags release.yml uses for its non-naive platforms. The naive tags are
       # left out on purpose: they need the Chromium/cronet toolchain, which costs
-      # minutes to fetch and adds nothing to a compile gate.
+      # minutes to fetch and adds nothing to this gate.
       BUILD_TAGS: with_quic,with_grpc,with_utls,with_acme,with_gvisor,badlinkname,tfogo_checklinkname0,with_tailscale
     steps:
       # The frontend is not needed to compile the backend, so this job never
@@ -64,6 +64,13 @@ jobs:
       # "invalid reference to crypto/tls.(*Conn).handlePostHandshakeMessage".
       - name: Build
         run: go build -ldflags="-w -s -checklinkname=0" -tags "$BUILD_TAGS" -o /dev/null .
+
+      # Test binaries link the same sing-box internals as the panel, so they
+      # need the same tags and -checklinkname=0 as the build above. Tests that
+      # hit sqlite go through cgo; ubuntu-latest ships gcc, so nothing extra
+      # to install.
+      - name: Test
+        run: go test -tags "$BUILD_TAGS" -ldflags="-checklinkname=0" ./...
 
   # Lived in the frontend repo's own ci.yml until that repo was inlined here.
   # It has to stay a gate: nothing else builds the frontend before a release, so

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,8 +157,8 @@ When adding new features, place code in the appropriate layer (handler → servi
 
 ### Current State
 
-- The project does not yet have a formal test suite (no `*_test.go` files in the repo).
-- CI currently focuses on **builds** (e.g. `release.yml`) rather than automated tests.
+- Unit tests live next to the code they cover (`*_test.go`, standard `testing` package).
+- Every PR runs `go vet`, `go build`, and `go test ./...` (the `backend` job in `.github/workflows/ci.yml`).
 
 ### What You Can Do Now
 
@@ -168,9 +168,15 @@ When adding new features, place code in the appropriate layer (handler → servi
    go build -ldflags "-w -s" -tags "with_quic,with_grpc,with_utls,with_acme,with_gvisor,with_tailscale" -o sui main.go
    ```
 
-2. **Manual testing**: Run with `./runSUI.sh`, test the changed area (panel, API, subscription, etc.).
+2. **Run the tests**: Same command CI uses — the tags and `-checklinkname=0` are both required for the test binaries to link:
 
-3. **Future tests**: Contributions that add **unit tests** (e.g. for `util/`, `service/`, or API handlers) or **integration tests** are very welcome. Prefer the standard library `testing` package and table-driven tests where appropriate.
+   ```bash
+   go test -tags "with_quic,with_grpc,with_utls,with_acme,with_gvisor,badlinkname,tfogo_checklinkname0,with_tailscale" -ldflags="-checklinkname=0" ./...
+   ```
+
+3. **Manual testing**: Run with `./runSUI.sh`, test the changed area (panel, API, subscription, etc.).
+
+4. **New tests**: Contributions that add **unit tests** (e.g. for `util/`, `service/`, or API handlers) or **integration tests** are very welcome. Prefer the standard library `testing` package and table-driven tests where appropriate.
 
 ### Running the Linter (optional)
 


### PR DESCRIPTION
## What

Add a `Test` step to the backend CI job, after `Build`:

```
go test -tags "$BUILD_TAGS" -ldflags="-checklinkname=0" ./...
```

The repo has five `*_test.go` files (`util/`, `service/`, `cmd/migration/`) that CI never executed. Also syncs CONTRIBUTING.md's Testing section, which still claimed the repo had no tests and CI ran none, and documents the exact local test command.

## Why the flags

Both are load-bearing, verified empirically:

- `-ldflags="-checklinkname=0"` — test binaries link the same sing-box internals as the panel; without it the link fails with `invalid reference to crypto/tls.(*Conn).handlePostHandshakeMessage` (sing-box badtls).
- `-tags "$BUILD_TAGS"` — same job-level tags Vet and Build already use.

No toolchain additions needed: the sqlite driver builds via cgo, and ubuntu-latest ships gcc (the Build step already exercises this path).

## Verification

Ran the exact CI command on linux/amd64 (Go 1.26.4, matching what setup-go resolves from go.mod):

- Current main (62a1ac4): `ok` for `cmd/migration`, `service`, `util`; exit 0. First confirmed full run of the existing suite.
- PR #95 head (adds `sub/jsonService_test.go`, which hits real sqlite): `ok` for all four test packages; exit 0 — so this gate will not turn #95 red once it picks up the new workflow.
