### PR TITLE
feat: opt-in node fanout for apiv2 save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ backup/
 bin/
 db/
 sui
+2s-ui
 web/html
 main
 tmp
@@ -34,3 +35,4 @@ windows/sui-*.exe
 # Claude Code local docs and config — keep out of the public repo.
 .claude/
 CLAUDE.md
+.mcp.json

--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ its own panel, so existing panels can be adopted as they are. Inbounds adopted
 from a node become read-only replicas on the master — edit them on the node they
 belong to.
 
+For API automation: `POST <panel path>apiv2/save` (the panel path is `/app/` by
+default, so `/app/apiv2/save`) triggers the web UI's immediate node fanout only
+when the request carries `sync=true`; without it, client/inbound changes still
+converge through the hourly reconcile safety net.
+
 ## Environment Variables
 
 <details>

--- a/api/apiHandler.go
+++ b/api/apiHandler.go
@@ -41,7 +41,12 @@ func (a *APIHandler) postHandler(c *gin.Context) {
 	case "changePass":
 		a.ApiService.ChangePass(c)
 	case "save":
-		a.ApiService.Save(c, loginUser, true)
+		hostname, err := a.ApiService.canonicalHost(c)
+		if err != nil {
+			jsonMsg(c, "", err)
+			return
+		}
+		a.ApiService.Save(c, loginUser, true, hostname)
 	case "adoptInbounds":
 		a.ApiService.AdoptInbounds(c, loginUser)
 	case "reconcileNode":

--- a/api/apiService.go
+++ b/api/apiService.go
@@ -75,9 +75,34 @@ func (a *ApiService) getData(c *gin.Context) (interface{}, error) {
 	}
 	var pd service.PanelDataService
 	if isUpdated {
-		return pd.FullPayload(getHostname(c))
+		// Read-only path: the host is rendered, not persisted, so a settings
+		// read failure degrades to the request Host rather than blanking the
+		// whole panel. The save path, where it would be written, still fails.
+		host, err := a.canonicalHost(c)
+		if err != nil {
+			logger.Warning("load: web domain unreadable, using request host: ", err)
+			host = getHostname(c)
+		}
+		return pd.FullPayload(host)
 	}
 	return pd.LivePayload()
+}
+
+// canonicalHost is the hostname baked into generated links and the advertised
+// subscription URI — values that outlive the request that produced them, so the
+// rule for picking it lives in one place. The configured web domain wins: it is
+// the spelling the operator chose, and it does not vary with how a caller
+// happened to reach the panel. A settings read failure is reported rather than
+// downgraded to the request Host, which is the value we must not persist.
+func (a *ApiService) canonicalHost(c *gin.Context) (string, error) {
+	webDomain, err := a.SettingService.GetWebDomain()
+	if err != nil {
+		return "", err
+	}
+	if host := normalizeHost(webDomain); host != "" {
+		return host, nil
+	}
+	return getHostname(c), nil
 }
 
 func (a *ApiService) LoadPartialData(c *gin.Context, objs []string) error {
@@ -117,7 +142,16 @@ func (a *ApiService) LoadPartialData(c *gin.Context, objs []string) error {
 			}
 			data[obj] = tlsConfigs
 		case "clients":
-			clients, err := a.ClientService.Get(id)
+			// full=1 is the cluster reconcile read: it needs config to diff
+			// against the master's copy. Everything else — the SPA list, the
+			// websocket payload, save responses — gets the lean projection.
+			var clients interface{}
+			var err error
+			if id == "" && c.Query("full") == "1" {
+				clients, err = a.ClientService.GetAllWithConfig()
+			} else {
+				clients, err = a.ClientService.Get(id)
+			}
 			if err != nil {
 				return err
 			}
@@ -276,12 +310,14 @@ func (a *ApiService) ChangePass(c *gin.Context) {
 	}
 }
 
-// Save handles POST api/save. fanout controls whether a successful client /
-// inbound change is propagated to managed nodes. v1 (the SPA) passes true; v2
-// passes false so a node that has this panel as a master does not bounce the
-// pushed change back out (ping-pong between mutual masters).
-func (a *ApiService) Save(c *gin.Context, loginUser string, fanout bool) {
-	hostname := getHostname(c)
+// Save handles POST api/save. fanout triggers an immediate node reconcile for
+// client/inbound changes (v1 always; v2 with sync=true). It affects latency
+// only — the hourly ReconcileAllOnline pushes state regardless — and is not
+// what prevents mutual-master ping-pong: a pushed client references the
+// receiving panel's own inbounds, so expectedClients' node_id scoping keeps it
+// out of every outgoing push. hostname feeds generated links; callers pick the
+// canonical value (v2 prefers the configured web domain over the request Host).
+func (a *ApiService) Save(c *gin.Context, loginUser string, fanout bool, hostname string) {
 	obj := c.Request.FormValue("object")
 	act := c.Request.FormValue("action")
 	data := c.Request.FormValue("data")
@@ -321,6 +357,11 @@ func (a *ApiService) ResetTraffic(c *gin.Context) {
 		jsonMsg(c, "resetTraffic", err)
 		return
 	}
+	// The reset re-enables depleted clients. DepleteJob fanned the disable out
+	// to nodes, so fan the re-enable out too — otherwise nodes keep rejecting
+	// paid-up users until the hourly safety net.
+	a.NodeSyncService.MarkAllDirty()
+	go a.NodeSyncService.ReconcileDirtyOnline()
 	err := a.ConfigService.RestartCore()
 	jsonMsg(c, "resetTraffic", err)
 }

--- a/api/apiV2Handler.go
+++ b/api/apiV2Handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"strconv"
 	"sync"
 	"time"
 
@@ -42,14 +43,35 @@ func (a *APIv2Handler) initRouter(g *gin.RouterGroup) {
 }
 
 func (a *APIv2Handler) postHandler(c *gin.Context) {
-	username := a.findUsername(c)
+	// Set by checkToken. A second findUsername could disagree with the one
+	// that passed auth (ReloadTokens swap or an expiry tick in between) and
+	// attribute the write to an empty actor.
+	username := c.GetString("username")
 	action := c.Param("postAction")
 
 	switch action {
 	case "save":
-		// fanout=false: a client pushed here by a master must not be bounced
-		// back out to this panel's own nodes (mutual-master ping-pong).
-		a.ApiService.Save(c, username, false)
+		// sync=true asks for the immediate node fanout the web UI always gets.
+		// It controls latency only — without it a change still reaches nodes
+		// via the hourly ReconcileAllOnline safety net. Loop safety for pushed
+		// changes lives in expectedClients' node_id scoping, not in this flag.
+		// Malformed values are rejected: silently degrading to "no fanout"
+		// would report success while nodes stay stale for up to an hour.
+		fanout := false
+		if v := c.Request.FormValue("sync"); v != "" {
+			parsed, err := strconv.ParseBool(v)
+			if err != nil {
+				jsonMsg(c, "sync", err)
+				return
+			}
+			fanout = parsed
+		}
+		hostname, err := a.canonicalHost(c)
+		if err != nil {
+			jsonMsg(c, "", err)
+			return
+		}
+		a.ApiService.Save(c, username, fanout, hostname)
 	case "restartApp":
 		a.ApiService.RestartApp(c)
 	case "restartSb":
@@ -132,6 +154,7 @@ func (a *APIv2Handler) findUsername(c *gin.Context) string {
 func (a *APIv2Handler) checkToken(c *gin.Context) {
 	username := a.findUsername(c)
 	if username != "" {
+		c.Set("username", username)
 		c.Next()
 		return
 	}

--- a/api/utils.go
+++ b/api/utils.go
@@ -38,8 +38,25 @@ func getHostname(c *gin.Context) string {
 // settings form accepts whatever was pasted into it.
 func normalizeHost(host string) string {
 	host = strings.TrimSpace(host)
+	// A pasted URL is rejected outright rather than trimmed into shape:
+	// SplitHostPort on "https://example.com" splits at the scheme's colon and
+	// hands back "https", which would then be baked into every generated link
+	// as the server name. Returning empty lets the caller fall back to the
+	// request Host, which is at least reachable.
+	if strings.ContainsAny(host, "/\\") {
+		return ""
+	}
 	if strings.Contains(host, ":") {
-		host, _, _ = net.SplitHostPort(host)
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			host = h
+		} else {
+			// No port to split off, so this is a bare IPv6 literal — a Host
+			// header always brackets one, but the settings field takes it
+			// either way. Unwrap so the re-bracketing below is idempotent;
+			// discarding the value here (what SplitHostPort's zero return
+			// used to do) silently blanked the host instead of bracketing it.
+			host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+		}
 		if strings.Contains(host, ":") {
 			host = "[" + host + "]"
 		}

--- a/api/utils.go
+++ b/api/utils.go
@@ -29,9 +29,17 @@ func getRemoteIp(c *gin.Context) string {
 }
 
 func getHostname(c *gin.Context) string {
-	host := c.Request.Host
+	return normalizeHost(c.Request.Host)
+}
+
+// normalizeHost strips the port and brackets a bare IPv6 literal, so the result
+// is usable as the server field of a generated link. Anything reaching link
+// generation must pass through here — a configured domain included, since the
+// settings form accepts whatever was pasted into it.
+func normalizeHost(host string) string {
+	host = strings.TrimSpace(host)
 	if strings.Contains(host, ":") {
-		host, _, _ = net.SplitHostPort(c.Request.Host)
+		host, _, _ = net.SplitHostPort(host)
 		if strings.Contains(host, ":") {
 			host = "[" + host + "]"
 		}

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -1,0 +1,41 @@
+package api
+
+import "testing"
+
+// normalizeHost feeds the server field of every generated link and the
+// advertised subscription URI, and now also sanitises the configured web
+// domain — which is whatever the operator pasted into the settings form.
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"bare domain", "example.com", "example.com"},
+		{"domain with port", "example.com:2053", "example.com"},
+		{"surrounding whitespace", "  example.com  ", "example.com"},
+		{"ipv4", "10.0.0.1", "10.0.0.1"},
+		{"ipv4 with port", "10.0.0.1:2053", "10.0.0.1"},
+		{"bracketed ipv6 with port", "[2001:db8::1]:2053", "[2001:db8::1]"},
+		// Both used to come back empty: SplitHostPort errors without a port and
+		// its zero return was assigned unconditionally.
+		{"bare ipv6 gets bracketed", "2001:db8::1", "[2001:db8::1]"},
+		{"bracketed ipv6 without a port stays bracketed once", "[2001:db8::1]", "[2001:db8::1]"},
+		// Regression guard: SplitHostPort splits "https://example.com" at the
+		// scheme colon and returns "https", which used to be baked into every
+		// link as the server name. Empty makes the caller fall back to the
+		// request Host.
+		{"pasted https url", "https://example.com", ""},
+		{"pasted http url with path", "http://example.com/app/", ""},
+		{"bare domain with a trailing slash", "example.com/", ""},
+		{"backslash", `example.com\app`, ""},
+		{"empty", "", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeHost(tc.in); got != tc.want {
+				t.Errorf("normalizeHost(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/cronjob/depleteJob.go
+++ b/cronjob/depleteJob.go
@@ -17,7 +17,7 @@ func NewDepleteJob() *DepleteJob {
 }
 
 func (s *DepleteJob) Run() {
-	inboundIds, disabled, err := s.ClientService.DepleteClients()
+	inboundIds, enableChanged, err := s.ClientService.DepleteClients()
 	if err != nil {
 		logger.Warning("Disable depleted users failed: ", err)
 		return
@@ -30,9 +30,12 @@ func (s *DepleteJob) Run() {
 			logger.Error("unable to update inbound users: ", err)
 		}
 	}
-	// Fan the disable out to nodes: reconcile sees enable=false in the expected
-	// set and pushes an edit; the node then hot-restarts and drops connections.
-	if len(disabled) > 0 {
+	// Fan the new enable state out to nodes: reconcile sees it in the expected
+	// set and pushes an edit; the node then hot-restarts and drops (or readmits)
+	// connections. Both directions have to go — a round that only re-enabled
+	// auto-reset clients still leaves the nodes rejecting paid-up users until
+	// the hourly safety net.
+	if len(enableChanged) > 0 {
 		s.NodeSyncService.MarkAllDirty()
 		go s.NodeSyncService.ReconcileDirtyOnline()
 	}

--- a/cronjob/resetTrafficJob.go
+++ b/cronjob/resetTrafficJob.go
@@ -13,6 +13,7 @@ type ResetTrafficJob struct {
 	service.ClientService
 	service.ConfigService
 	service.SettingService
+	service.NodeSyncService
 	schedule cron.Schedule
 }
 
@@ -42,6 +43,10 @@ func (s *ResetTrafficJob) Run() {
 		logger.Warning("ResetTrafficJob: reset all clients failed: ", err)
 		return
 	}
+	// The reset re-enables depleted clients; fan it out like DepleteJob's
+	// disable so nodes stop rejecting them before the hourly safety net.
+	s.NodeSyncService.MarkAllDirty()
+	go s.NodeSyncService.ReconcileDirtyOnline()
 
 	// Advance to the next boundary. schedule.Next returns the nearest upcoming
 	// occurrence, so if several periods were missed (e.g. downtime) it snaps

--- a/database/db.go
+++ b/database/db.go
@@ -59,7 +59,17 @@ func OpenDB(dbPath string) error {
 	// _cache_size=-200 caps each connection's page cache at ~200 KiB
 	// (default is ~2 MiB), reducing memory amplification if a connection
 	// escapes the pool.
-	dsn := dbPath + sep + "_busy_timeout=10000&_journal_mode=WAL&_cache_size=-200"
+	//
+	// _txlock=immediate makes every transaction take the write lock up front.
+	// Without it a deferred transaction that reads and then writes — which is
+	// what every read-modify-write here is, client.Links being the hottest —
+	// gets SQLITE_BUSY when another connection committed in between, and
+	// _busy_timeout does NOT cover that case: the busy handler is not invoked
+	// for a stale-snapshot conflict, so the transaction just fails. Taking the
+	// lock at BEGIN turns that into an ordinary lock wait, which _busy_timeout
+	// does cover. Every transaction in this codebase writes, so nothing pays
+	// for a write lock it does not need.
+	dsn := dbPath + sep + "_busy_timeout=10000&_journal_mode=WAL&_cache_size=-200&_txlock=immediate"
 	db, err = gorm.Open(sqlite.Open(dsn), c)
 	if err != nil {
 		return err

--- a/frontend/src/layouts/drawers/client/ClientDrawer.vue
+++ b/frontend/src/layouts/drawers/client/ClientDrawer.vue
@@ -162,6 +162,15 @@
 
       <!-- ===================== Links ===================== -->
       <div v-else-if="tab === 'links'">
+        <!-- One copy for the whole set: proxy clients import a newline-separated
+             list, so copying row by row is the wrong unit of work. -->
+        <div v-if="allImportableLinks.length > 0" style="display: flex; align-items: center; margin-bottom: 10px;">
+          <SectionLabel>{{ $t('client.links') }}</SectionLabel>
+          <div style="flex: 1;" />
+          <Btn variant="subtle" sm @click="copyToClipboard(allImportableLinks.join('\n'))">
+            <Ico name="copy" :size="14" /> {{ $t('actions.copyAll') }}
+          </Btn>
+        </div>
         <template v-if="localLinks.length > 0">
           <div style="display: flex; flex-direction: column; gap: 7px; margin-bottom: 16px;">
             <div
@@ -172,6 +181,26 @@
               @click="copyToClipboard(lnk.uri)"
             >
               <span class="mono" style="color: var(--text-3); flex: none;">{{ i + 1 }}</span>
+              <span class="mono link-uri" dir="ltr">{{ lnk.uri }}</span>
+              <Ico name="copy" :size="13" style="color: var(--text-3); flex: none;" />
+            </div>
+          </div>
+          <hr class="form-divider" />
+        </template>
+
+        <!-- Node links are maintained by cluster reconciliation; shown read-only
+             because the server re-derives them and would revert any edit here. -->
+        <template v-if="nodeLinks.length > 0">
+          <SectionLabel style="margin-bottom: 10px;">{{ $t('pages.nodes') }}</SectionLabel>
+          <div style="display: flex; flex-direction: column; gap: 7px; margin-bottom: 16px;">
+            <div
+              v-for="(lnk, i) in nodeLinks"
+              :key="'node' + i"
+              class="link-row"
+              :title="$t('copyToClipboard')"
+              @click="copyToClipboard(lnk.uri)"
+            >
+              <span class="mono" style="color: var(--text-3); flex: none;">{{ lnk.remark }}</span>
               <span class="mono link-uri" dir="ltr">{{ lnk.uri }}</span>
               <Ico name="copy" :size="13" style="color: var(--text-3); flex: none;" />
             </div>
@@ -254,8 +283,22 @@ const loading = ref(false)
 const client = ref<Client>(createClient())
 const clientConfig = ref<any>({})
 const extLinks = ref<Link[]>([])
+const nodeLinks = ref<Link[]>([])
 const subLinks = ref<Link[]>([])
 const localLinks = computed(() => client.value.links?.filter((l) => l.type == 'local') ?? [])
+// Everything a proxy client can import as a node, in the order shown. External
+// subscriptions are left out: they are URLs to subscribe to, not node URIs.
+const allImportableLinks = computed(() => [
+  ...localLinks.value.map((l) => l.uri),
+  ...nodeLinks.value.map((l) => l.uri),
+  ...extLinks.value.map((l) => l.uri).filter((u) => u != ''),
+])
+// Node links are external links the server owns: reconciliation rewrites them
+// from each node's snapshot, and a save re-reads them from the row rather than
+// the payload. Editing one here would be reverted without a word, so they are
+// listed read-only alongside the local links instead of in the editable list.
+const isNodeOwned = (remark?: string) =>
+  !!remark && Data().nodes.some((n: any) => remark.startsWith(`[${n.name}] `))
 
 const tabs = computed((): [string, string][] => [
   ['general', t('ui.general')],
@@ -379,16 +422,23 @@ const percentColor = computed(() => {
   if (client.value.up + client.value.down >= client.value.volume) return 'var(--rose)'
   return percent.value > 90 ? 'var(--amber)' : 'var(--brand)'
 })
+// The server treats the traffic counters as its own and only accepts the ones a
+// request actually carries, so sending them is how a reset is expressed. This
+// flag is that intent: without it a drawer left open would save counters read
+// minutes ago and roll back everything the stats job recorded meanwhile.
+const didReset = ref(false)
 const resetUsage = () => {
   client.value.totalUp = (client.value.totalUp ?? 0) + client.value.up
   client.value.totalDown = (client.value.totalDown ?? 0) + client.value.down
   client.value.up = 0
   client.value.down = 0
+  didReset.value = true
 }
 
 // ---------- lifecycle / save (payload identical to legacy modals/Client.vue) ----------
 const updateData = async (id: number) => {
   tab.value = 'general'
+  didReset.value = false
   if (id > 0) {
     loading.value = true
     const newData = await Data().loadClients(id)
@@ -403,7 +453,9 @@ const updateData = async (id: number) => {
     clientConfig.value = randomConfigs('client')
   }
   // links are kept untouched and merged back into the payload on save
-  extLinks.value = client.value.links?.filter((l) => l.type == 'external') ?? []
+  extLinks.value =
+    client.value.links?.filter((l) => l.type == 'external' && !isNodeOwned(l.remark)) ?? []
+  nodeLinks.value = client.value.links?.filter((l) => l.type == 'external' && isNodeOwned(l.remark)) ?? []
   subLinks.value = client.value.links?.filter((l) => l.type == 'sub') ?? []
 }
 
@@ -422,7 +474,14 @@ const saveChanges = async () => {
     ...extLinks.value.filter((l) => l.uri != ''),
     ...subLinks.value.filter((l) => l.uri != ''),
   ]
-  const success = await Data().save('clients', props.id == 0 ? 'new' : 'edit', client.value)
+  const payload: any = { ...client.value }
+  if (!didReset.value) {
+    delete payload.up
+    delete payload.down
+    delete payload.totalUp
+    delete payload.totalDown
+  }
+  const success = await Data().save('clients', props.id == 0 ? 'new' : 'edit', payload)
   if (success) emit('close')
   loading.value = false
 }
@@ -433,6 +492,29 @@ watch(() => props.visible, (v) => {
 </script>
 
 <style scoped>
+/* Both read-only link lists (local and node) already used these class names;
+   they had no rule, so the rows rendered as one run-on line of text. */
+.link-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 7px 10px;
+  border-radius: 8px;
+  background: var(--surface-2);
+  cursor: pointer;
+}
+.link-row:hover {
+  background: var(--surface-3);
+}
+/* No truncation: these URIs get selected and pasted into proxy clients, so the
+   whole string has to stay visible and selectable. */
+.link-uri {
+  flex: 1;
+  min-width: 0;
+  font-size: 12.5px;
+  word-break: break-all;
+}
 .access-head {
   display: flex;
   align-items: center;

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -156,6 +156,7 @@ export default {
     resetTraffic: "Reset traffic",
     updatePanel: "Update panel",
     reset: "Reset",
+    copyAll: "Copy all",
     adopt: "Adopt",
   },
   login: {

--- a/frontend/src/locales/fa.ts
+++ b/frontend/src/locales/fa.ts
@@ -154,6 +154,7 @@ export default {
     resetTraffic: "بازنشانی ترافیک",
     updatePanel: "به‌روزرسانی پنل",
     reset: "بازنشانی",
+    copyAll: "کپی همه",
     adopt: "پذیرش",
   },
   login: {

--- a/frontend/src/locales/ru.ts
+++ b/frontend/src/locales/ru.ts
@@ -155,6 +155,7 @@ export default {
     resetTraffic: "Сброс трафика",
     updatePanel: "Обновление панели",
     reset: "Сбросить",
+    copyAll: "Копировать все",
     adopt: "Принять",
   },
   login: {

--- a/frontend/src/locales/vi.ts
+++ b/frontend/src/locales/vi.ts
@@ -154,6 +154,7 @@ export default {
     resetTraffic: "Đặt lại lưu lượng",
     updatePanel: "Cập nhật ứng dụng",
     reset: "Đặt lại",
+    copyAll: "Sao chép tất cả",
     adopt: "Nhận",
   },
   login: {

--- a/frontend/src/locales/zhcn.ts
+++ b/frontend/src/locales/zhcn.ts
@@ -154,6 +154,7 @@ export default {
     resetTraffic: "重置流量",
     updatePanel: "更新面板",
     reset: "重置",
+    copyAll: "复制全部",
     adopt: "采纳",
   },
   login: {

--- a/frontend/src/locales/zhtw.ts
+++ b/frontend/src/locales/zhtw.ts
@@ -154,6 +154,7 @@ export default {
     resetTraffic: "重置流量",
     updatePanel: "更新面板",
     reset: "重置",
+    copyAll: "複製全部",
     adopt: "採納",
   },
   login: {

--- a/frontend/src/views/Clients.vue
+++ b/frontend/src/views/Clients.vue
@@ -376,8 +376,16 @@ const toggleEnable = async (c: any) => {
   try {
     const full = await Data().loadClients(c.id)
     if (full?.id) {
-      full.enable = !c.enable
-      await Data().save('clients', 'edit', full)
+      // The counters are server-owned and only the ones a request carries are
+      // taken as authoritative, so sending the values read a moment ago would
+      // roll back whatever the stats job recorded in between. Same rule as the
+      // drawer, which sends them only when Reset was actually clicked.
+      const payload: any = { ...full, enable: !c.enable }
+      delete payload.up
+      delete payload.down
+      delete payload.totalUp
+      delete payload.totalDown
+      await Data().save('clients', 'edit', payload)
     }
   } finally {
     toggling.value = { ...toggling.value, [c.id]: false }

--- a/service/client.go
+++ b/service/client.go
@@ -471,6 +471,12 @@ func (s *ClientService) UpdateClientsOnInboundDelete(tx *gorm.DB, id uint, tag s
 	if err != nil {
 		return err
 	}
+	// Needed to recognise this inbound's node-owned links below; hoisted out of
+	// the loop since it does not vary per client.
+	var nodeNames []string
+	if err = tx.Model(model.Node{}).Pluck("name", &nodeNames).Error; err != nil {
+		return err
+	}
 	for _, client := range clients {
 		// Delete inbounds
 		var clientInbounds, newClientInbounds []uint
@@ -491,7 +497,7 @@ func (s *ClientService) UpdateClientsOnInboundDelete(tx *gorm.DB, id uint, tag s
 		json.Unmarshal(client.Links, &clientLinks)
 		for _, clientLink := range clientLinks {
 			remark := clientLink["remark"]
-			if remark == tag || (strings.HasPrefix(remark, "[") && strings.HasSuffix(remark, "] "+tag)) {
+			if remark == tag || isNodeLinkFor(remark, tag, nodeNames) {
 				continue
 			}
 			newClientLinks = append(newClientLinks, clientLink)

--- a/service/client.go
+++ b/service/client.go
@@ -3,7 +3,6 @@ package service
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"strings"
 	"time"
 
@@ -230,12 +229,12 @@ func (s *ClientService) preserveServerManagedFields(tx *gorm.DB, client *model.C
 	var existing model.Client
 	err := tx.Model(model.Client{}).Select("created_at", "online_at", "up", "down", "total_up", "total_down").
 		Where("id = ?", client.Id).First(&existing).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return nil
-	}
 	if err != nil {
-		// Not just "no such row": failing open here would write the payload's
-		// zeroed counters and destroy the node's traffic history.
+		// ErrRecordNotFound included, deliberately: failing open here would write
+		// the payload's zeroed counters and destroy the node's traffic history,
+		// and an edit whose row vanished has nothing to preserve onto anyway.
+		// Both callers load the row via findInboundsChanges first, so in practice
+		// this only fires on a concurrent delete.
 		return err
 	}
 	client.CreatedAt = existing.CreatedAt
@@ -323,6 +322,34 @@ func (s *ClientService) updateLinksWithFixedInbounds(tx *gorm.DB, clients []*mod
 		}
 	}
 
+	// Stored links for the existing clients, in one query rather than one per
+	// client — editbulk submits the whole selection through here. An id missing
+	// from the map is a row that vanished concurrently: nothing to re-attach.
+	storedLinksById := map[uint]json.RawMessage{}
+	if len(nodeNames) > 0 {
+		var ids []uint
+		for _, client := range clients {
+			if client.Id != 0 {
+				ids = append(ids, client.Id)
+			}
+		}
+		if len(ids) > 0 {
+			var rows []struct {
+				Id    uint
+				Links json.RawMessage
+			}
+			if err := tx.Model(model.Client{}).Select("id", "links").
+				Where("id in ?", ids).Scan(&rows).Error; err != nil {
+				// Failing open would persist the list with every node link
+				// stripped — the exact loss this re-attach exists to prevent.
+				return err
+			}
+			for _, r := range rows {
+				storedLinksById[r.Id] = r.Links
+			}
+		}
+	}
+
 	for index, client := range clients {
 		var clientLinks []map[string]string
 		if err := json.Unmarshal(client.Links, &clientLinks); err != nil {
@@ -360,41 +387,29 @@ func (s *ClientService) updateLinksWithFixedInbounds(tx *gorm.DB, clients []*mod
 			}
 			newClientLinks = append(newClientLinks, clientLink)
 		}
-		if reattach {
-			var stored model.Client
-			err := tx.Model(model.Client{}).Select("links").
-				Where("id = ?", client.Id).First(&stored).Error
-			switch {
-			case errors.Is(err, gorm.ErrRecordNotFound):
-				// Concurrently deleted; there is nothing to re-attach.
-			case err != nil:
-				// Failing open would persist the list with every node link
-				// stripped — the exact loss this re-attach exists to prevent.
+		if stored := storedLinksById[client.Id]; reattach && len(stored) > 0 {
+			var storedLinks []map[string]string
+			if err := json.Unmarshal(stored, &storedLinks); err != nil {
 				return err
-			case len(stored.Links) > 0:
-				var storedLinks []map[string]string
-				if err := json.Unmarshal(stored.Links, &storedLinks); err != nil {
-					return err
+			}
+			keptTags := map[string]bool{}
+			for _, id := range clientInboundIds[index] {
+				if tag, ok := replicaTagById[id]; ok {
+					keptTags[tag] = true
 				}
-				keptTags := map[string]bool{}
-				for _, id := range clientInboundIds[index] {
-					if tag, ok := replicaTagById[id]; ok {
-						keptTags[tag] = true
-					}
+			}
+			for _, l := range storedLinks {
+				// type must be checked too: a local inbound tagged like a
+				// node prefix is regenerated above, and re-appending the
+				// stored copy would duplicate it once per save, forever.
+				if l["type"] == "local" || !isNodeOwnedRemark(l["remark"], nodeNames) {
+					continue
 				}
-				for _, l := range storedLinks {
-					// type must be checked too: a local inbound tagged like a
-					// node prefix is regenerated above, and re-appending the
-					// stored copy would duplicate it once per save, forever.
-					if l["type"] == "local" || !isNodeOwnedRemark(l["remark"], nodeNames) {
-						continue
-					}
-					sep := strings.Index(l["remark"], "] ")
-					if sep < 0 || !keptTags[l["remark"][sep+2:]] {
-						continue // inbound no longer bound to this client
-					}
-					newClientLinks = append(newClientLinks, l)
+				sep := strings.Index(l["remark"], "] ")
+				if sep < 0 || !keptTags[l["remark"][sep+2:]] {
+					continue // inbound no longer bound to this client
 				}
+				newClientLinks = append(newClientLinks, l)
 			}
 		}
 

--- a/service/client.go
+++ b/service/client.go
@@ -83,6 +83,31 @@ func (s *ClientService) Save(tx *gorm.DB, act string, data json.RawMessage, host
 		if err != nil {
 			return nil, err
 		}
+		if act == "edit" {
+			// Only a name actually changing is validated, so a duplicate that
+			// predates this check stays editable on its other fields — same
+			// stance as the node-name bracket rule.
+			var oldName string
+			if err = tx.Model(model.Client{}).Select("name").
+				Where("id = ?", client.Id).Scan(&oldName).Error; err != nil {
+				return nil, err
+			}
+			if oldName != client.Name {
+				if err = s.ensureNameAvailable(tx, client.Name, client.Id); err != nil {
+					return nil, err
+				}
+			}
+		} else if client.Group != clusterGroup {
+			// A cluster push is exempt: runReconcile aborts the WHOLE round on a
+			// failed push, so one name a node happens to use locally would stop
+			// that node syncing entirely — a worse failure than the duplicate
+			// this check exists to prevent. A same-group duplicate cannot reach
+			// here anyway: actualClusterClients would have found it and the
+			// master would be pushing an edit instead of a new.
+			if err = s.ensureNameAvailable(tx, client.Name, 0); err != nil {
+				return nil, err
+			}
+		}
 		if err = setConfigIdentity(&client); err != nil {
 			return nil, err
 		}
@@ -117,6 +142,26 @@ func (s *ClientService) Save(tx *gorm.DB, act string, data json.RawMessage, host
 			return nil, err
 		}
 		now := time.Now().Unix()
+		// Name check for the whole batch in one query rather than per client —
+		// this path imports hundreds at a time. `seen` covers duplicates within
+		// the batch, which the table cannot show: none of them are committed yet.
+		names := make([]string, 0, len(clients))
+		seen := make(map[string]bool, len(clients))
+		for _, client := range clients {
+			if seen[client.Name] {
+				return nil, common.NewErrorf("duplicate client name in this batch: %q", client.Name)
+			}
+			seen[client.Name] = true
+			names = append(names, client.Name)
+		}
+		var taken []string
+		if err = tx.Model(model.Client{}).Where("name in ?", names).
+			Pluck("name", &taken).Error; err != nil {
+			return nil, err
+		}
+		if len(taken) > 0 {
+			return nil, common.NewErrorf("client name %q already exists", taken[0])
+		}
 		for _, client := range clients {
 			if err = setConfigIdentity(client); err != nil {
 				return nil, err
@@ -141,6 +186,45 @@ func (s *ClientService) Save(tx *gorm.DB, act string, data json.RawMessage, host
 		err = json.Unmarshal(data, &clients)
 		if err != nil {
 			return nil, err
+		}
+		// Renames are validated as a batch — one query for the stored names,
+		// then a conflict check only for the ones actually changing. The SPA
+		// never renames through this path (it submits the list projection
+		// unchanged), so the common case costs a single extra query.
+		ids := make([]uint, 0, len(clients))
+		for _, client := range clients {
+			if client.Id != 0 {
+				ids = append(ids, client.Id)
+			}
+		}
+		oldNameById := make(map[uint]string, len(ids))
+		if len(ids) > 0 {
+			var stored []struct {
+				Id   uint
+				Name string
+			}
+			if err = tx.Model(model.Client{}).Select("id", "name").
+				Where("id in ?", ids).Scan(&stored).Error; err != nil {
+				return nil, err
+			}
+			for _, row := range stored {
+				oldNameById[row.Id] = row.Name
+			}
+		}
+		renamedTo := make(map[string]bool)
+		for _, client := range clients {
+			if oldNameById[client.Id] == client.Name {
+				continue
+			}
+			// Two rows renamed to the same new name would both pass the DB
+			// check — neither is committed yet.
+			if renamedTo[client.Name] {
+				return nil, common.NewErrorf("duplicate client name in this batch: %q", client.Name)
+			}
+			renamedTo[client.Name] = true
+			if err = s.ensureNameAvailable(tx, client.Name, client.Id); err != nil {
+				return nil, err
+			}
 		}
 		for _, client := range clients {
 			changedInboundIds, err := s.findInboundsChanges(tx, client, true)
@@ -216,6 +300,29 @@ func (s *ClientService) Save(tx *gorm.DB, act string, data json.RawMessage, host
 	}
 
 	return inboundIds, nil
+}
+
+// ensureNameAvailable rejects a duplicate client name. The name is the cluster's
+// identity key — expectedClients and actualClusterClients both map by it — so two
+// clients sharing one means only ever syncing whichever the map iteration kept,
+// silently and forever. There is no unique index to lean on (the column predates
+// the cluster feature and existing installs may already hold duplicates), and the
+// only guard until now was the SPA's own check, which apiv2 callers bypass. Same
+// loud-failure stance as the adoption tag-collision check. excludeId skips the row
+// being edited; pass 0 for a create.
+func (s *ClientService) ensureNameAvailable(tx *gorm.DB, name string, excludeId uint) error {
+	q := tx.Model(model.Client{}).Where("name = ?", name)
+	if excludeId != 0 {
+		q = q.Where("id <> ?", excludeId)
+	}
+	var count int64
+	if err := q.Count(&count).Error; err != nil {
+		return err
+	}
+	if count > 0 {
+		return common.NewErrorf("client name %q already exists", name)
+	}
+	return nil
 }
 
 // preserveServerManagedFields restores columns the server owns from the stored

--- a/service/client.go
+++ b/service/client.go
@@ -555,14 +555,17 @@ func (s *ClientService) UpdateLinksByInboundChange(tx *gorm.DB, inbounds *[]mode
 }
 
 // DepleteClients disables clients over quota or past expiry and returns both
-// the affected local inbound ids (to hot-restart) and the disabled client names
-// (so the caller can fan the disable out to nodes). With cluster totals folded
-// into up/down, the quota check is already a whole-cluster judgement.
+// the affected local inbound ids (to hot-restart) and the names whose enable
+// state changed, so the caller can fan those out to nodes. That second list
+// covers BOTH directions: the depletion disable below and the periodic reset's
+// re-enable inside ResetClients — a round that only re-enables still has to
+// reach the nodes, or they keep rejecting a paid-up user. With cluster totals
+// folded into up/down, the quota check is already a whole-cluster judgement.
 func (s *ClientService) DepleteClients() ([]uint, []string, error) {
 	var err error
 	var clients []model.Client
 	var changes []model.Changes
-	var users []string
+	var enableChanged []string
 	var inboundIds []uint
 
 	dt := time.Now().Unix()
@@ -583,7 +586,7 @@ func (s *ClientService) DepleteClients() ([]uint, []string, error) {
 	}()
 
 	// Reset clients
-	inboundIds, err = s.ResetClients(tx, dt)
+	inboundIds, enableChanged, err = s.ResetClients(tx, dt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -596,7 +599,7 @@ func (s *ClientService) DepleteClients() ([]uint, []string, error) {
 
 	for _, client := range clients {
 		logger.Debug("Client ", client.Name, " is going to be disabled")
-		users = append(users, client.Name)
+		enableChanged = append(enableChanged, client.Name)
 		var userInbounds []uint
 		json.Unmarshal(client.Inbounds, &userInbounds)
 		// Find changed inbounds
@@ -623,19 +626,24 @@ func (s *ClientService) DepleteClients() ([]uint, []string, error) {
 		MarkLastUpdate(dt)
 	}
 
-	return inboundIds, users, nil
+	return inboundIds, enableChanged, nil
 }
 
-func (s *ClientService) ResetClients(tx *gorm.DB, dt int64) ([]uint, error) {
+// ResetClients applies the per-client periodic reset. It returns the affected
+// local inbound ids (to hot-restart) and the names it re-enabled, which the
+// caller has to fan out to nodes for the same reason DepleteJob fans out a
+// disable: the node keeps rejecting a paid-up user until it hears otherwise.
+func (s *ClientService) ResetClients(tx *gorm.DB, dt int64) ([]uint, []string, error) {
 	var err error
 	var resetClients, allClients []*model.Client
 	var changes []model.Changes
 	var inboundIds []uint
+	var reenabled []string
 	// Set delay start without periodic reset
 	err = tx.Model(model.Client{}).
 		Where("enable = true AND delay_start = true AND auto_reset = false AND (Up + Down) > 0").Find(&resetClients).Error
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for _, client := range resetClients {
 		client.Expiry = dt + (int64(client.ResetDays) * 86400)
@@ -654,7 +662,7 @@ func (s *ClientService) ResetClients(tx *gorm.DB, dt int64) ([]uint, error) {
 	err = tx.Model(model.Client{}).
 		Where("enable = true AND delay_start = true AND auto_reset = true AND (Up + Down) > 0").Find(&resetClients).Error
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for _, client := range resetClients {
 		client.NextReset = dt + (int64(client.ResetDays) * 86400)
@@ -673,7 +681,7 @@ func (s *ClientService) ResetClients(tx *gorm.DB, dt int64) ([]uint, error) {
 	err = tx.Model(model.Client{}).
 		Where("delay_start = false AND auto_reset = true AND next_reset < ?", dt).Find(&resetClients).Error
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	for _, client := range resetClients {
 		client.NextReset = dt + (int64(client.ResetDays) * 86400)
@@ -683,6 +691,7 @@ func (s *ClientService) ResetClients(tx *gorm.DB, dt int64) ([]uint, error) {
 		client.Down = 0
 		if !client.Enable {
 			client.Enable = true
+			reenabled = append(reenabled, client.Name)
 			var clientInboundIds []uint
 			json.Unmarshal(client.Inbounds, &clientInboundIds)
 			inboundIds = common.UnionUintArray(inboundIds, clientInboundIds)
@@ -694,7 +703,7 @@ func (s *ClientService) ResetClients(tx *gorm.DB, dt int64) ([]uint, error) {
 	if len(allClients) > 0 {
 		err = tx.Save(allClients).Error
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -702,11 +711,11 @@ func (s *ClientService) ResetClients(tx *gorm.DB, dt int64) ([]uint, error) {
 	if len(changes) > 0 {
 		err = tx.Model(model.Changes{}).Create(&changes).Error
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		MarkLastUpdate(dt)
 	}
-	return inboundIds, nil
+	return inboundIds, reenabled, nil
 }
 
 // ResetAllClientsTraffic zeroes up/down for every client (accumulating into the

--- a/service/client.go
+++ b/service/client.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"strings"
 	"time"
 
@@ -24,6 +25,10 @@ func (s *ClientService) Get(id string) (*[]model.Client, error) {
 	return s.getById(id)
 }
 
+// getById returns the whole row on purpose — do NOT narrow it to
+// clientListColumns. The drawer edits from this shape, and the counters it
+// omits have no omitempty, so a projection here would send zeros the client
+// would then echo back as an intentional-looking value.
 func (s *ClientService) getById(id string) (*[]model.Client, error) {
 	db := database.GetDB()
 	var client []model.Client
@@ -39,7 +44,28 @@ func (s *ClientService) GetAll() (*[]model.Client, error) {
 	db := database.GetDB()
 	var clients []model.Client
 	err := db.Model(model.Client{}).
-		Select("`id`, `enable`, `name`, `desc`, `group`, `remark`, `inbounds`, `up`, `down`, `volume`, `expiry`, `created_at`, `online_at`").
+		Select(clientListColumns).
+		Scan(&clients).Error
+	if err != nil {
+		return nil, err
+	}
+	return &clients, nil
+}
+
+// clientListColumns deliberately omits config and links: both are large and
+// config carries every protocol's credentials. This projection feeds the client
+// list, the websocket full payload and every save response, so anything added
+// here is paid on all three. Consumers needing the full row fetch it by id.
+const clientListColumns = "`id`, `enable`, `name`, `desc`, `group`, `remark`, `inbounds`, `up`, `down`, `volume`, `expiry`, `created_at`, `online_at`"
+
+// GetAllWithConfig adds config for the cluster reconcile diff only: clientDiffers
+// compares it, and an absent key reads as "always different", which would re-push
+// every client every round. Reached solely by the node-facing apiv2 clients read.
+func (s *ClientService) GetAllWithConfig() (*[]model.Client, error) {
+	db := database.GetDB()
+	var clients []model.Client
+	err := db.Model(model.Client{}).
+		Select(clientListColumns + ", `config`").
 		Scan(&clients).Error
 	if err != nil {
 		return nil, err
@@ -71,8 +97,9 @@ func (s *ClientService) Save(tx *gorm.DB, act string, data json.RawMessage, host
 			if err != nil {
 				return nil, err
 			}
-			// Preserve managed timestamps (immutable createdAt, stats-managed onlineAt)
-			s.preserveTimestamps(tx, &client)
+			if err = s.preserveServerManagedFields(tx, &client, payloadFields(data)); err != nil {
+				return nil, err
+			}
 		} else {
 			client.CreatedAt = time.Now().Unix()
 			err = json.Unmarshal(client.Inbounds, &inboundIds)
@@ -124,7 +151,11 @@ func (s *ClientService) Save(tx *gorm.DB, act string, data json.RawMessage, host
 			if err = setConfigIdentity(client); err != nil {
 				return nil, err
 			}
-			s.preserveTimestamps(tx, client)
+			// nil: the bulk payload is the list projection, so none of the
+			// counters it carries are authoritative — take them all from the row.
+			if err = s.preserveServerManagedFields(tx, client, nil); err != nil {
+				return nil, err
+			}
 			if len(changedInboundIds) > 0 {
 				inboundIds = common.UnionUintArray(inboundIds, changedInboundIds)
 			}
@@ -188,14 +219,54 @@ func (s *ClientService) Save(tx *gorm.DB, act string, data json.RawMessage, host
 	return inboundIds, nil
 }
 
-func (s *ClientService) preserveTimestamps(tx *gorm.DB, client *model.Client) {
+// preserveServerManagedFields restores columns the server owns from the stored
+// row. createdAt/onlineAt always; the traffic counters only when the request did
+// not carry them, which is what separates the two kinds of caller: a master's
+// node push omits them (they would unmarshal as zero and wipe the node's
+// totals), while the SPA sends them — and its per-client "Reset" button works by
+// sending zeroed ones, so overwriting those would silently undo the reset.
+// payloadHas nil means "carried nothing", i.e. preserve every counter.
+func (s *ClientService) preserveServerManagedFields(tx *gorm.DB, client *model.Client, payloadHas map[string]bool) error {
 	var existing model.Client
-	if err := tx.Model(model.Client{}).Select("created_at", "online_at").
-		Where("id = ?", client.Id).First(&existing).Error; err != nil {
-		return
+	err := tx.Model(model.Client{}).Select("created_at", "online_at", "up", "down", "total_up", "total_down").
+		Where("id = ?", client.Id).First(&existing).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil
+	}
+	if err != nil {
+		// Not just "no such row": failing open here would write the payload's
+		// zeroed counters and destroy the node's traffic history.
+		return err
 	}
 	client.CreatedAt = existing.CreatedAt
 	client.OnlineAt = existing.OnlineAt
+	if !payloadHas["up"] {
+		client.Up = existing.Up
+	}
+	if !payloadHas["down"] {
+		client.Down = existing.Down
+	}
+	if !payloadHas["totalUp"] {
+		client.TotalUp = existing.TotalUp
+	}
+	if !payloadHas["totalDown"] {
+		client.TotalDown = existing.TotalDown
+	}
+	return nil
+}
+
+// payloadFields reports which keys the request object actually carried, so an
+// omitted server-managed value is preserved rather than written as zero.
+func payloadFields(data json.RawMessage) map[string]bool {
+	var raw map[string]json.RawMessage
+	if json.Unmarshal(data, &raw) != nil {
+		return nil
+	}
+	fields := make(map[string]bool, len(raw))
+	for k := range raw {
+		fields[k] = true
+	}
+	return fields
 }
 
 func (s *ClientService) updateLinksWithFixedInbounds(tx *gorm.DB, clients []*model.Client, hostname string) error {
@@ -226,6 +297,32 @@ func (s *ClientService) updateLinksWithFixedInbounds(tx *gorm.DB, clients []*mod
 		inboundById[inbounds[i].Id] = &inbounds[i]
 	}
 
+	// Node links are system-owned (refreshNodeLinks rewrites them), so for an
+	// existing client they come from the stored row, not the request payload: a
+	// tab loaded before the last reconcile would otherwise strip them all, and
+	// nothing repairs that until the next reconcile touches this node.
+	var nodeNames []string
+	if err := tx.Model(model.Node{}).Pluck("name", &nodeNames).Error; err != nil {
+		return err
+	}
+
+	// Replica inbounds the payload still references, by tag. A node link is
+	// re-attached only while its inbound is still bound to the client:
+	// otherwise revoking access would leave a working link in the subscription
+	// until refreshNodeLinks next runs, which needs that node to be online — so
+	// revoking a user from an offline node would not take effect at all.
+	replicaTagById := map[uint]string{}
+	if len(allIds) > 0 {
+		var replicas []model.Inbound
+		if err := tx.Model(model.Inbound{}).Select("id", "tag").
+			Where("id in ? and node_id IS NOT NULL", allIds).Find(&replicas).Error; err != nil {
+			return err
+		}
+		for _, r := range replicas {
+			replicaTagById[r.Id] = r.Tag
+		}
+	}
+
 	for index, client := range clients {
 		var clientLinks []map[string]string
 		if err := json.Unmarshal(client.Links, &clientLinks); err != nil {
@@ -248,10 +345,56 @@ func (s *ClientService) updateLinksWithFixedInbounds(tx *gorm.DB, clients []*mod
 			}
 		}
 
-		// Add non local links
+		// A client being created has no stored row to re-attach from, so its
+		// payload links are kept verbatim — filtering them would drop a
+		// user-authored link whose remark merely looks node-owned.
+		reattach := client.Id != 0 && len(nodeNames) > 0
+
+		// Add non local links (node-owned ones re-attach from the DB below)
 		for _, clientLink := range clientLinks {
-			if clientLink["type"] != "local" {
-				newClientLinks = append(newClientLinks, clientLink)
+			if clientLink["type"] == "local" {
+				continue
+			}
+			if reattach && isNodeOwnedRemark(clientLink["remark"], nodeNames) {
+				continue
+			}
+			newClientLinks = append(newClientLinks, clientLink)
+		}
+		if reattach {
+			var stored model.Client
+			err := tx.Model(model.Client{}).Select("links").
+				Where("id = ?", client.Id).First(&stored).Error
+			switch {
+			case errors.Is(err, gorm.ErrRecordNotFound):
+				// Concurrently deleted; there is nothing to re-attach.
+			case err != nil:
+				// Failing open would persist the list with every node link
+				// stripped — the exact loss this re-attach exists to prevent.
+				return err
+			case len(stored.Links) > 0:
+				var storedLinks []map[string]string
+				if err := json.Unmarshal(stored.Links, &storedLinks); err != nil {
+					return err
+				}
+				keptTags := map[string]bool{}
+				for _, id := range clientInboundIds[index] {
+					if tag, ok := replicaTagById[id]; ok {
+						keptTags[tag] = true
+					}
+				}
+				for _, l := range storedLinks {
+					// type must be checked too: a local inbound tagged like a
+					// node prefix is regenerated above, and re-appending the
+					// stored copy would duplicate it once per save, forever.
+					if l["type"] == "local" || !isNodeOwnedRemark(l["remark"], nodeNames) {
+						continue
+					}
+					sep := strings.Index(l["remark"], "] ")
+					if sep < 0 || !keptTags[l["remark"][sep+2:]] {
+						continue // inbound no longer bound to this client
+					}
+					newClientLinks = append(newClientLinks, l)
+				}
 			}
 		}
 
@@ -341,13 +484,17 @@ func (s *ClientService) UpdateClientsOnInboundDelete(tx *gorm.DB, id uint, tag s
 		if err != nil {
 			return err
 		}
-		// Delete links
+		// Delete links. A node link for the same inbound carries the tag behind
+		// a "[<node>] " prefix, so an exact match alone would leave it behind
+		// for good: nothing else strips links for an inbound that is gone.
 		var clientLinks, newClientLinks []map[string]string
 		json.Unmarshal(client.Links, &clientLinks)
 		for _, clientLink := range clientLinks {
-			if clientLink["remark"] != tag {
-				newClientLinks = append(newClientLinks, clientLink)
+			remark := clientLink["remark"]
+			if remark == tag || (strings.HasPrefix(remark, "[") && strings.HasSuffix(remark, "] "+tag)) {
+				continue
 			}
+			newClientLinks = append(newClientLinks, clientLink)
 		}
 		client.Links, err = json.MarshalIndent(newClientLinks, "", "  ")
 		if err != nil {
@@ -631,8 +778,16 @@ func (s *ClientService) findInboundsChanges(tx *gorm.DB, client *model.Client, f
 		return nil, err
 	}
 	if fillOmitted {
+		// The bulk path submits the client list projection, which cannot carry
+		// these columns; the payload's zero values would silently wipe them —
+		// switching off periodic auto-reset and zeroing next_reset, so
+		// ResetClientsTraffic's "next_reset < now" scan never matches again.
 		client.Links = oldClient.Links
 		client.Config = oldClient.Config
+		client.AutoReset = oldClient.AutoReset
+		client.ResetDays = oldClient.ResetDays
+		client.NextReset = oldClient.NextReset
+		client.DelayStart = oldClient.DelayStart
 	}
 	err = json.Unmarshal(oldClient.Inbounds, &oldInboundIds)
 	if err != nil {

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -1,0 +1,123 @@
+package service
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/shenaba/2s-ui/database/model"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	gormlogger "gorm.io/gorm/logger"
+)
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: gormlogger.Discard})
+	if err != nil {
+		t.Fatalf("open in-memory db: %v", err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("db handle: %v", err)
+	}
+	// One connection, or each pooled connection gets its own empty :memory: db.
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(&model.Client{}, &model.Inbound{}, &model.Node{}, &model.Tls{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+// A node push must never be blocked by a name the node happens to use locally:
+// runReconcile aborts the WHOLE round on a failed push, so one collision would
+// stop that node syncing entirely — worse than the duplicate the check prevents.
+func TestSaveNameCheckExemptsClusterPush(t *testing.T) {
+	db := newTestDB(t)
+	var svc ClientService
+
+	local := model.Client{
+		Name: "X", Group: "user",
+		Inbounds: json.RawMessage(`[]`), Links: json.RawMessage(`[]`), Config: json.RawMessage(`{}`),
+	}
+	if err := db.Create(&local).Error; err != nil {
+		t.Fatalf("seed local client: %v", err)
+	}
+
+	t.Run("normal create still rejects a duplicate", func(t *testing.T) {
+		data := json.RawMessage(`{"name":"X","group":"user","inbounds":[],"links":[],"config":{}}`)
+		if _, err := svc.Save(db, "new", data, "example.com"); err == nil {
+			t.Fatal("duplicate name accepted on a normal create")
+		}
+	})
+
+	t.Run("cluster push goes through", func(t *testing.T) {
+		data := json.RawMessage(`{"name":"X","group":"@cluster","inbounds":[],"links":[],"config":{}}`)
+		if _, err := svc.Save(db, "new", data, "example.com"); err != nil {
+			t.Fatalf("cluster push rejected by the name check: %v", err)
+		}
+		var n int64
+		db.Model(model.Client{}).Where("name = ?", "X").Count(&n)
+		if n != 2 {
+			t.Errorf("expected the pushed @cluster client alongside the local one, got %d rows", n)
+		}
+	})
+}
+
+// payloadFields is what separates a master's node push (omits the counters, so
+// they must be preserved) from the SPA's per-client Reset (sends zeroed ones,
+// which must be written). Getting it wrong either wipes a node's traffic
+// history or silently undoes a reset.
+func TestPayloadFields(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want map[string]bool
+	}{
+		{
+			name: "node push omits the counters",
+			data: `{"name":"x","enable":true,"config":{},"inbounds":[1],"links":[],"volume":0,"expiry":0,"group":"@cluster","desc":""}`,
+			want: map[string]bool{
+				"name": true, "enable": true, "config": true, "inbounds": true,
+				"links": true, "volume": true, "expiry": true, "group": true, "desc": true,
+			},
+		},
+		{
+			name: "reset carries all four",
+			data: `{"id":3,"name":"x","up":0,"down":0,"totalUp":50,"totalDown":60}`,
+			want: map[string]bool{
+				"id": true, "name": true, "up": true, "down": true,
+				"totalUp": true, "totalDown": true,
+			},
+		},
+		{
+			name: "explicit null still counts as carried",
+			data: `{"up":null}`,
+			want: map[string]bool{"up": true},
+		},
+		{
+			name: "empty object carries nothing",
+			data: `{}`,
+			want: map[string]bool{},
+		},
+		{
+			name: "malformed payload reports nothing rather than guessing",
+			data: `[1,2,3]`,
+			want: nil,
+		},
+		{
+			name: "garbage reports nothing",
+			data: `not json`,
+			want: nil,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := payloadFields(json.RawMessage(tc.data))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("payloadFields(%s) = %v, want %v", tc.data, got, tc.want)
+			}
+		})
+	}
+}

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -65,6 +65,67 @@ func TestSaveNameCheckExemptsClusterPush(t *testing.T) {
 	})
 }
 
+// editbulk validates only the names that actually change: the SPA submits the
+// list projection back unchanged, so the ordinary path must not trip the check,
+// while an apiv2 caller can rename through here.
+func TestSaveEditbulkRenames(t *testing.T) {
+	db := newTestDB(t)
+	var svc ClientService
+
+	seed := func(name string) uint {
+		c := model.Client{
+			Name: name, Group: "user",
+			Inbounds: json.RawMessage(`[]`), Links: json.RawMessage(`[]`), Config: json.RawMessage(`{}`),
+		}
+		if err := db.Create(&c).Error; err != nil {
+			t.Fatalf("seed %q: %v", name, err)
+		}
+		return c.Id
+	}
+	idA, idB := seed("a"), seed("b")
+
+	row := func(id uint, name string) map[string]any {
+		return map[string]any{
+			"id": id, "name": name, "group": "user",
+			"inbounds": []uint{}, "links": []map[string]string{}, "config": map[string]any{},
+		}
+	}
+	editbulk := func(rows ...map[string]any) error {
+		data, err := json.Marshal(rows)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		_, err = svc.Save(db, "editbulk", data, "example.com")
+		return err
+	}
+
+	t.Run("rename onto an existing name is rejected", func(t *testing.T) {
+		if err := editbulk(row(idA, "b")); err == nil {
+			t.Error("rename onto a name another row holds was accepted")
+		}
+	})
+	// Neither row is committed yet, so the table cannot show this collision.
+	t.Run("two rows renamed to the same new name are rejected", func(t *testing.T) {
+		if err := editbulk(row(idA, "same"), row(idB, "same")); err == nil {
+			t.Error("batch-internal duplicate was accepted")
+		}
+	})
+	t.Run("unchanged names pass", func(t *testing.T) {
+		if err := editbulk(row(idA, "a"), row(idB, "b")); err != nil {
+			t.Errorf("the SPA's ordinary submit was rejected: %v", err)
+		}
+	})
+
+	// Nothing above may have renamed anything.
+	var names []string
+	if err := db.Model(model.Client{}).Order("id").Pluck("name", &names).Error; err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if len(names) != 2 || names[0] != "a" || names[1] != "b" {
+		t.Errorf("names changed by a rejected batch: %v", names)
+	}
+}
+
 // payloadFields is what separates a master's node push (omits the counters, so
 // they must be preserved) from the SPA's per-client Reset (sends zeroed ones,
 // which must be written). Getting it wrong either wipes a node's traffic

--- a/service/config.go
+++ b/service/config.go
@@ -267,7 +267,11 @@ func (s *ConfigService) Save(obj string, act string, data json.RawMessage, initU
 			data = redactNodeToken(data)
 		}
 	default:
-		return nil, common.NewError("unknown object: ", obj)
+		// Assign the named err: the deferred closure keys off it, and a fresh
+		// return value would leave it nil — committing the (empty) txn, waking
+		// the hub, and even starting a stopped core for a failed request.
+		err = common.NewError("unknown object: ", obj)
+		return nil, err
 	}
 	if err != nil {
 		return nil, err

--- a/service/node.go
+++ b/service/node.go
@@ -82,6 +82,18 @@ func normalizeCertPin(pin string) string {
 	return pin
 }
 
+// httpStatusError turns a node's non-200 into something diagnosable. 403 is
+// almost always the node's own DomainValidator rejecting the Host we dialed:
+// the panel answers only to its configured web domain, so an address entered as
+// a bare IP is refused before the token is ever read — and the empty body gives
+// the operator nothing to go on.
+func httpStatusError(status int) error {
+	if status == http.StatusForbidden {
+		return common.NewError("HTTP 403 from node panel — if it has a web domain configured, its address here must use that domain, not an IP")
+	}
+	return common.NewErrorf("HTTP %d from node panel", status)
+}
+
 func nodeApiURL(n *model.Node, action string) string {
 	return strings.TrimRight(n.BaseUrl, "/") + normalizeWebPath(n.WebPath) + "apiv2/" + action
 }
@@ -151,7 +163,7 @@ func (s *NodeService) nodeGet(n *model.Node, client *http.Client, action string,
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, common.NewErrorf("HTTP %d from node panel", resp.StatusCode)
+		return nil, httpStatusError(resp.StatusCode)
 	}
 	var msg struct {
 		Success bool            `json:"success"`
@@ -407,6 +419,15 @@ func (s *NodeService) Save(tx *gorm.DB, act string, data json.RawMessage) error 
 		if node.Token == "" {
 			return common.NewError("node API token is required")
 		}
+		// The name is the aggregated-link marker (see nodeLinkPrefix), so a
+		// bracket in it would make one node's prefix match another's links — the
+		// two would then strip and re-add each other's every reconcile. Only
+		// enforced on the name actually being introduced: a node created before
+		// this rule must stay editable (token, baseUrl, enable) without being
+		// forced through a rename it did not ask for.
+		if (act == "new" || oldName != node.Name) && strings.ContainsAny(node.Name, "[]") {
+			return common.NewError("node name cannot contain [ or ]")
+		}
 		err = tx.Save(&node).Error
 		if err != nil {
 			return err
@@ -455,8 +476,8 @@ func (s *NodeService) Save(tx *gorm.DB, act string, data json.RawMessage) error 
 // "[new] " across every client, so renaming a node doesn't orphan the external
 // links refreshNodeLinks emits under the node name. Runs in the node-save tx.
 func renameNodeLinkPrefix(tx *gorm.DB, oldName, newName string) error {
-	oldPrefix := "[" + oldName + "] "
-	newPrefix := "[" + newName + "] "
+	oldPrefix := nodeLinkPrefix(oldName)
+	newPrefix := nodeLinkPrefix(newName)
 	var clients []model.Client
 	if err := tx.Model(model.Client{}).Find(&clients).Error; err != nil {
 		return err

--- a/service/nodeSync.go
+++ b/service/nodeSync.go
@@ -599,6 +599,13 @@ func clientDiffers(want map[string]interface{}, cur nodeClientState) bool {
 	// yields on either end. The cost of a false "differs" is a re-push per client
 	// per round, each writing a credential-bearing changes row that nothing
 	// prunes, so treat absence as "cannot compare", not as "differs".
+	//
+	// The price of that choice: a node-side config that was CLEARED (someone
+	// edited an @cluster client in the node's own UI) reads as "cannot compare"
+	// too, so the safety net will not repair it — this diff self-heals a changed
+	// config, not a deleted one. Comparing whenever either side has a config
+	// would cover it, at the cost of re-pushing every client every round against
+	// any node too old to return the column.
 	wantConfig, _ := want["config"].(json.RawMessage)
 	if len(wantConfig) > 0 && len(cur.Config) > 0 && !jsonEqual(wantConfig, cur.Config) {
 		return true

--- a/service/nodeSync.go
+++ b/service/nodeSync.go
@@ -50,6 +50,22 @@ var (
 	dirtyGen uint64
 )
 
+// nodeLinkPrefix is the single definition of the remark convention marking a
+// client link as owned by a node: refreshNodeLinks stamps it, client saves use
+// it to tell system links from user links, node renames rewrite it and inbound
+// deletes strip it. Keep every one of those going through here.
+func nodeLinkPrefix(nodeName string) string { return "[" + nodeName + "] " }
+
+// isNodeOwnedRemark reports whether a remark was emitted for any known node.
+func isNodeOwnedRemark(remark string, nodeNames []string) bool {
+	for _, n := range nodeNames {
+		if strings.HasPrefix(remark, nodeLinkPrefix(n)) {
+			return true
+		}
+	}
+	return false
+}
+
 // refreshLinksMu serializes the read-modify-write of client.Links across nodes.
 // ReconcileDirtyOnline fans out one goroutine per dirty node and any client/inbound
 // save marks every node dirty, so two nodes' refreshNodeLinks can hit the SAME
@@ -77,7 +93,7 @@ func (s *NodeSyncService) nodePost(n *model.Node, client *http.Client, action st
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, common.NewErrorf("HTTP %d from node panel", resp.StatusCode)
+		return nil, httpStatusError(resp.StatusCode)
 	}
 	var msg struct {
 		Success bool            `json:"success"`
@@ -97,6 +113,10 @@ func (s *NodeSyncService) nodePost(n *model.Node, client *http.Client, action st
 }
 
 // pushClient runs one clients save (new|edit|del) against a node.
+// The form carries no "sync" field, so the receiving panel does not immediately
+// fan the change out to its own nodes — there is nothing to fan out (see
+// ApiService.Save for why a pushed client can never enter an outgoing set), and
+// paying for a reconcile sweep per pushed client would be pure waste.
 func (s *NodeSyncService) pushClient(n *model.Node, client *http.Client, act string, payload interface{}) (json.RawMessage, error) {
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -507,7 +527,9 @@ func (s *NodeSyncService) expectedClients(nodeId uint, tagToId map[string]uint) 
 }
 
 func (s *NodeSyncService) actualClusterClients(node *model.Node, client *http.Client) (map[string]nodeClientState, error) {
-	obj, err := s.nodeGet(node, client, "clients", nil)
+	// full=1 asks the node to include config, which clientDiffers needs; without
+	// it every client would read as changed and be re-pushed every round.
+	obj, err := s.nodeGet(node, client, "clients", url.Values{"full": {"1"}})
 	if err != nil {
 		return nil, err
 	}
@@ -556,7 +578,15 @@ func clientDiffers(want map[string]interface{}, cur nodeClientState) bool {
 	if asInt64(want["expiry"]) != cur.Expiry {
 		return true
 	}
-	if !jsonEqual(want["config"], cur.Config) {
+	// Compare config only when both sides actually carry one. jsonEqual fails on
+	// a nil operand, so an absent config would report EVERY client as changed on
+	// EVERY round — which is exactly what an older node yields, since its clients
+	// projection has no config column, and what a client saved without a config
+	// yields on either end. The cost of a false "differs" is a re-push per client
+	// per round, each writing a credential-bearing changes row that nothing
+	// prunes, so treat absence as "cannot compare", not as "differs".
+	wantConfig, _ := want["config"].(json.RawMessage)
+	if len(wantConfig) > 0 && len(cur.Config) > 0 && !jsonEqual(wantConfig, cur.Config) {
 		return true
 	}
 	if !jsonEqual(want["inbounds"], cur.Inbounds) {
@@ -678,7 +708,7 @@ func (s *NodeSyncService) refreshNodeLinks(node *model.Node) {
 		return
 	}
 
-	prefix := "[" + node.Name + "] "
+	prefix := nodeLinkPrefix(node.Name)
 	touched := false
 
 	for i := range clients {
@@ -706,7 +736,11 @@ func (s *NodeSyncService) refreshNodeLinks(node *model.Node) {
 		hadPrefix := false
 		kept := make([]map[string]string, 0, len(existing))
 		for _, l := range existing {
-			if strings.HasPrefix(l["remark"], prefix) {
+			// Only our own external entries: a LOCAL inbound whose tag happens to
+			// start with this node's prefix generates a link with the same remark,
+			// and stripping it here would drop it from the subscription until an
+			// unrelated client save regenerated it.
+			if l["type"] != "local" && strings.HasPrefix(l["remark"], prefix) {
 				hadPrefix = true
 				continue
 			}
@@ -751,7 +785,9 @@ func (s *NodeSyncService) refreshNodeLinks(node *model.Node) {
 
 func (s *NodeSyncService) MarkAllDirty() {
 	bumpDirtyGen()
-	if err := database.GetDB().Model(model.Node{}).Where("enable = ?", true).Update("dirty", true).Error; err != nil {
+	// dirty = false predicate: this runs on the request path of every fanout
+	// save, so skip rewriting rows that are already flagged.
+	if err := database.GetDB().Model(model.Node{}).Where("enable = ? AND dirty = ?", true, false).Update("dirty", true).Error; err != nil {
 		logger.Warning("nodes: mark all dirty: ", err)
 	}
 }
@@ -760,7 +796,9 @@ func (s *NodeSyncService) MarkAllDirty() {
 // Called by the heartbeat so offline-period edits converge once a node returns.
 func (s *NodeSyncService) ReconcileDirtyOnline() {
 	var nodes []model.Node
-	if err := database.GetDB().Model(model.Node{}).Where("enable = ? AND dirty = ?", true, true).Find(&nodes).Error; err != nil {
+	// Select("id"): only the id is used, and a full Find would hydrate every
+	// node's Baselines blob and Token on each trigger.
+	if err := database.GetDB().Model(model.Node{}).Select("id").Where("enable = ? AND dirty = ?", true, true).Find(&nodes).Error; err != nil {
 		return
 	}
 	statuses := s.GetStatuses()
@@ -782,7 +820,7 @@ func (s *NodeSyncService) ReconcileDirtyOnline() {
 // the hourly safety net that repairs silent node-side drift.
 func (s *NodeSyncService) ReconcileAllOnline() {
 	var nodes []model.Node
-	if err := database.GetDB().Model(model.Node{}).Where("enable = ?", true).Find(&nodes).Error; err != nil {
+	if err := database.GetDB().Model(model.Node{}).Select("id").Where("enable = ?", true).Find(&nodes).Error; err != nil {
 		return
 	}
 	statuses := s.GetStatuses()

--- a/service/nodeSync.go
+++ b/service/nodeSync.go
@@ -66,6 +66,20 @@ func isNodeOwnedRemark(remark string, nodeNames []string) bool {
 	return false
 }
 
+// isNodeLinkFor reports whether a remark is the node-owned link for this exact
+// tag. Matching the whole "[<node>] <tag>" rather than prefix-plus-suffix keeps
+// a user-authored external link that merely looks the part — remark "[backup]
+// vless-in" on an unrelated entry — out of the blast radius when that tag's
+// inbound is deleted.
+func isNodeLinkFor(remark, tag string, nodeNames []string) bool {
+	for _, n := range nodeNames {
+		if remark == nodeLinkPrefix(n)+tag {
+			return true
+		}
+	}
+	return false
+}
+
 // refreshLinksMu serializes the read-modify-write of client.Links across nodes.
 // ReconcileDirtyOnline fans out one goroutine per dirty node and any client/inbound
 // save marks every node dirty, so two nodes' refreshNodeLinks can hit the SAME

--- a/service/nodeSync_test.go
+++ b/service/nodeSync_test.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestIsNodeOwnedRemark(t *testing.T) {
+	nodes := []string{"eu", "eu-2", "us west"}
+	tests := []struct {
+		name   string
+		remark string
+		want   bool
+	}{
+		{"exact node link", "[eu] vless-in", true},
+		{"node name with a space", "[us west] tcp", true},
+		// The "] " terminator is what keeps one node's prefix from swallowing
+		// another whose name starts with it; node names may not contain
+		// brackets precisely so this holds.
+		{"longer node name is not a prefix match", "[eu-2] vless-in", true},
+		{"user link that only looks the part", "[backup] vless-in", false},
+		{"bare tag", "vless-in", false},
+		{"empty", "", false},
+		{"prefix without the separator", "[eu]vless-in", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNodeOwnedRemark(tc.remark, nodes); got != tc.want {
+				t.Errorf("isNodeOwnedRemark(%q) = %v, want %v", tc.remark, got, tc.want)
+			}
+		})
+	}
+}
+
+// Regression guard: an inbound delete used to strip anything shaped like
+// "[...] <tag>", which caught user-authored links too.
+func TestIsNodeLinkFor(t *testing.T) {
+	nodes := []string{"eu", "us"}
+	tests := []struct {
+		name   string
+		remark string
+		tag    string
+		want   bool
+	}{
+		{"node link for this tag", "[eu] vless-in", "vless-in", true},
+		{"node link for another tag", "[eu] trojan-in", "vless-in", false},
+		{"unknown node", "[backup] vless-in", "vless-in", false},
+		{"bare tag is not a node link", "vless-in", "vless-in", false},
+		{"tag is a suffix of a longer one", "[eu] my-vless-in", "vless-in", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isNodeLinkFor(tc.remark, tc.tag, nodes); got != tc.want {
+				t.Errorf("isNodeLinkFor(%q, %q) = %v, want %v", tc.remark, tc.tag, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClientDiffers(t *testing.T) {
+	cfg := json.RawMessage(`{"vless":{"uuid":"a"}}`)
+	cfgReordered := json.RawMessage(`{"vless":{"uuid":"a"} }`)
+	cfgOther := json.RawMessage(`{"vless":{"uuid":"b"}}`)
+	inbounds := json.RawMessage(`[1,2]`)
+
+	want := func(mods map[string]interface{}) map[string]interface{} {
+		m := map[string]interface{}{
+			"enable":   true,
+			"expiry":   int64(100),
+			"config":   cfg,
+			"inbounds": inbounds,
+		}
+		for k, v := range mods {
+			m[k] = v
+		}
+		return m
+	}
+	cur := nodeClientState{Enable: true, Expiry: 100, Config: cfg, Inbounds: inbounds}
+
+	t.Run("identical", func(t *testing.T) {
+		if clientDiffers(want(nil), cur) {
+			t.Error("identical state reported as differing")
+		}
+	})
+	t.Run("config compared structurally, not byte-wise", func(t *testing.T) {
+		c := cur
+		c.Config = cfgReordered
+		if clientDiffers(want(nil), c) {
+			t.Error("whitespace-only config difference reported as differing")
+		}
+	})
+	t.Run("real config change", func(t *testing.T) {
+		c := cur
+		c.Config = cfgOther
+		if !clientDiffers(want(nil), c) {
+			t.Error("changed config not detected")
+		}
+	})
+	t.Run("enable and expiry", func(t *testing.T) {
+		if !clientDiffers(want(map[string]interface{}{"enable": false}), cur) {
+			t.Error("changed enable not detected")
+		}
+		if !clientDiffers(want(map[string]interface{}{"expiry": int64(200)}), cur) {
+			t.Error("changed expiry not detected")
+		}
+	})
+	t.Run("inbounds", func(t *testing.T) {
+		c := cur
+		c.Inbounds = json.RawMessage(`[1]`)
+		if !clientDiffers(want(nil), c) {
+			t.Error("changed inbounds not detected")
+		}
+	})
+
+	// The reason the both-sides-present guard exists: an older node's clients
+	// projection has no config column, and treating that as "differs" re-pushed
+	// every client every round, each push appending a credential-bearing
+	// changes row that nothing prunes.
+	//
+	// The same assertion pins the accepted cost of that guard: a node-side
+	// config someone CLEARED is indistinguishable from an old node's missing
+	// column, so the safety net will not repair it either.
+	t.Run("absent node config is not a difference", func(t *testing.T) {
+		c := cur
+		c.Config = nil
+		if clientDiffers(want(nil), c) {
+			t.Error("node without a config column reported as differing")
+		}
+		c.Config = json.RawMessage("")
+		if clientDiffers(want(nil), c) {
+			t.Error("node with an empty config reported as differing")
+		}
+	})
+	t.Run("absent master config is not a difference", func(t *testing.T) {
+		if clientDiffers(want(map[string]interface{}{"config": json.RawMessage(nil)}), cur) {
+			t.Error("configless master client reported as differing")
+		}
+	})
+	// Other fields must still be compared when config cannot be.
+	t.Run("other fields still compared without config", func(t *testing.T) {
+		c := cur
+		c.Config = nil
+		c.Enable = false
+		if !clientDiffers(want(nil), c) {
+			t.Error("enable change missed when config was absent")
+		}
+	})
+}

--- a/web/web.go
+++ b/web/web.go
@@ -76,6 +76,13 @@ func (s *Server) initRouter() (*gin.Engine, error) {
 	}
 
 	if webDomain != "" {
+		// Pins every route, apiv2 included. Exempting apiv2 for masters dialing
+		// a node by IP was considered and rejected: TLS gets there first (the
+		// master sends no SNI, so an HTTPS node with a domain rejects the
+		// handshake outright), which leaves only the plain-HTTP-with-a-domain
+		// case — while the carve-out would cost an unpinned Host on every apiv2
+		// route. A node with a web domain must be dialed by that domain; when
+		// it is not, nodeGet/nodePost say so.
 		engine.Use(middleware.DomainValidator(webDomain))
 	}
 


### PR DESCRIPTION
`POST <panel path>apiv2/save` now honours a `sync` form value. Without it a
client/inbound change converges through the hourly reconcile; with it the nodes
are pushed immediately, the way the web UI always has. Malformed values are
rejected rather than silently degrading to "no fanout".

Loop safety was never this flag's job — `expectedClients`' `node_id` scoping is
what keeps a pushed client out of every outgoing set — so the comments claiming
otherwise are corrected.

## Cluster bugs fixed along the way

Reviewing that surface turned up a number of pre-existing problems:

- **Every `@cluster` client was re-pushed every reconcile round.** `clientDiffers`
  compared a `config` the node's clients projection never sent, so the compare
  always failed. Each spurious push appended a credential-bearing `changes` row,
  and nothing prunes that table. Config now ships only to the reconcile read
  (`full=1`) — keeping it off the websocket payload and out of browser sessions —
  and is compared only when both sides carry one, which also covers
  mixed-version clusters and configless clients.
- **Node pushes wiped the node's traffic history.** A push omits the counters and
  `Save` wrote them back as zero. They are now preserved unless the request
  actually carries them, which is how the per-client reset expresses itself: the
  drawer sends them only after Reset is clicked, so an edit from a drawer left
  open no longer rolls back what the stats job recorded meanwhile.
- **`editbulk` silently switched off periodic auto-reset**, writing the list
  projection's omitted columns back as zeros.
- **A stale tab stripped every cluster route from a client's subscription.**
  Node-owned links were taken from the request payload; they now come from the
  stored row, scoped to the replica inbounds the client still references so
  revoking access takes effect even while that node is offline. The drawer
  renders them read-only.
- **Resetting traffic left paid-up users rejected for up to an hour** — it
  re-enables depleted clients but never told the nodes.
- **The `[node] ` link marker had four independent encodings.** Now one; inbound
  deletion strips the prefixed form, and node names may no longer contain
  brackets that would make two nodes' prefixes overlap.
- **`ConfigService.Save`'s unknown-object branch left the named `err` nil**, so
  the deferred commit, hub notify and core start ran for a failed request.

The hostname baked into generated links and the advertised subscription URI is
now resolved in one place, preferring the configured web domain and normalising
it the same way a request Host is.

## UI

Links in the client drawer are no longer truncated, and a copy-all button hands
the whole set over for bulk import into a proxy client.

## Verification

`go vet`, the full tagged build and `vue-tsc` all pass. Functionally verified on
a real panel:

- edit without Reset preserves counters; Reset + save zeroes `up`/`down` and
  rolls the totals correctly
- `apiv2/clients` omits `config`, `apiv2/clients?full=1` includes it
- node links render read-only and separate from user-owned external links
- copy-all copies the whole set

No automated tests — the `api` package has no test scaffolding today, which is
tracked separately.
