### PR TITLE
fix: port the upstream v1.5.5 fixes that still apply here

### DIFF
--- a/frontend/src/types/dns.ts
+++ b/frontend/src/types/dns.ts
@@ -55,8 +55,11 @@ const defaultValues: Record<DnsType, DnsServer> = {
 export function createDnsServer<T extends DnsServer>(type: string, json?: Partial<T>): DnsServer {
   // Deep copy: a shallow spread hands every new server the very same nested
   // objects (tls, headers, path), so filling in one form rewrites the defaults
-  // the next one starts from.
-  const defaultObject: DnsServer = { ...JSON.parse(JSON.stringify(defaultValues[type] ?? {})), ...(json || {}) }
+  // the next one starts from. The clone is annotated because spreading
+  // JSON.parse's `any` would make the literal `any` too and stop TypeScript
+  // from checking it.
+  const base: DnsServer = JSON.parse(JSON.stringify(defaultValues[type] ?? {}))
+  const defaultObject: DnsServer = { ...base, ...(json || {}) }
   return defaultObject
 }
 

--- a/frontend/src/types/dns.ts
+++ b/frontend/src/types/dns.ts
@@ -53,7 +53,10 @@ const defaultValues: Record<DnsType, DnsServer> = {
   resolved: { type: 'resolved' },
 }
 export function createDnsServer<T extends DnsServer>(type: string, json?: Partial<T>): DnsServer {
-  const defaultObject: DnsServer = { ...defaultValues[type], ...(json || {}) }
+  // Deep copy: a shallow spread hands every new server the very same nested
+  // objects (tls, headers, path), so filling in one form rewrites the defaults
+  // the next one starts from.
+  const defaultObject: DnsServer = { ...JSON.parse(JSON.stringify(defaultValues[type] ?? {})), ...(json || {}) }
   return defaultObject
 }
 

--- a/frontend/src/types/endpoints.ts
+++ b/frontend/src/types/endpoints.ts
@@ -77,6 +77,9 @@ const defaultValues: Record<EpType, Endpoint> = {
 }
 
 export function createEndpoint<T extends Endpoint>(type: string,json?: Partial<T>): Endpoint {
-  const defaultObject: Endpoint = { ...defaultValues[type], ...(json || {}) }
+  // Deep copy: a shallow spread hands every new endpoint the very same nested
+  // address and peers arrays, so filling in one form rewrites the defaults the
+  // next one starts from.
+  const defaultObject: Endpoint = { ...JSON.parse(JSON.stringify(defaultValues[type] ?? {})), ...(json || {}) }
   return defaultObject
 }

--- a/frontend/src/types/endpoints.ts
+++ b/frontend/src/types/endpoints.ts
@@ -79,7 +79,9 @@ const defaultValues: Record<EpType, Endpoint> = {
 export function createEndpoint<T extends Endpoint>(type: string,json?: Partial<T>): Endpoint {
   // Deep copy: a shallow spread hands every new endpoint the very same nested
   // address and peers arrays, so filling in one form rewrites the defaults the
-  // next one starts from.
-  const defaultObject: Endpoint = { ...JSON.parse(JSON.stringify(defaultValues[type] ?? {})), ...(json || {}) }
+  // next one starts from. The clone is annotated because spreading JSON.parse's
+  // `any` would make the literal `any` too and stop TypeScript from checking it.
+  const base: Endpoint = JSON.parse(JSON.stringify(defaultValues[type] ?? {}))
+  const defaultObject: Endpoint = { ...base, ...(json || {}) }
   return defaultObject
 }

--- a/frontend/src/types/inbounds.ts
+++ b/frontend/src/types/inbounds.ts
@@ -216,7 +216,10 @@ const defaultValues: Record<InType, Inbound> = {
   trojan: <Trojan>{ type: InTypes.Trojan, tls_id: 0, transport: {} },
   naive: <Naive>{ type: InTypes.Naive, tls_id: 0 },
   hysteria: <Hysteria>{ type: InTypes.Hysteria, up_mbps: 100, down_mbps: 100, tls_id: 0 },
-  shadowtls: <ShadowTLS>{ type: InTypes.ShadowTLS, version: 3, handshake: {}, handshake_for_server_name: {} },
+  // handshake.server_port has no sing-box default; leaving it unset makes the
+  // inbound fail to start, so seed the port the handshake server almost always
+  // listens on.
+  shadowtls: <ShadowTLS>{ type: InTypes.ShadowTLS, version: 3, handshake: { server_port: 443 }, handshake_for_server_name: {} },
   tuic: <TUIC>{ type: InTypes.TUIC, congestion_control: "cubic", tls_id: 0 },
   hysteria2: <Hysteria2>{ type: InTypes.Hysteria2, tls_id: 0 },
   vless: <VLESS>{ type: InTypes.VLESS, tls_id: 0, transport: {} },

--- a/frontend/src/types/inbounds.ts
+++ b/frontend/src/types/inbounds.ts
@@ -93,6 +93,7 @@ export interface Trojan extends InboundBasics {
   transport?: Transport
 }
 export interface Naive extends InboundBasics {
+  network?: "udp" | "tcp"
   tls: iTls,
   quic_congestion_control?: "" | "bbr" | "bbr2" | "cubic" | "reno"
 }

--- a/frontend/src/types/inbounds.ts
+++ b/frontend/src/types/inbounds.ts
@@ -240,6 +240,9 @@ const defaultValues: Record<InType, Inbound> = {
 }
 
 export function createInbound<T extends Inbound>(type: InType,json?: Partial<T>): Inbound {
-  const defaultObject: Inbound = { ...defaultValues[type] ?? {}, ...(json ?? {}) }
+  // Deep copy: a shallow spread hands every new inbound the very same nested
+  // objects (handshake, transport, padding_scheme), so filling in one form
+  // rewrites the defaults the next one starts from.
+  const defaultObject: Inbound = { ...JSON.parse(JSON.stringify(defaultValues[type] ?? {})), ...(json ?? {}) }
   return defaultObject
 }

--- a/frontend/src/types/inbounds.ts
+++ b/frontend/src/types/inbounds.ts
@@ -243,7 +243,10 @@ const defaultValues: Record<InType, Inbound> = {
 export function createInbound<T extends Inbound>(type: InType,json?: Partial<T>): Inbound {
   // Deep copy: a shallow spread hands every new inbound the very same nested
   // objects (handshake, transport, padding_scheme), so filling in one form
-  // rewrites the defaults the next one starts from.
-  const defaultObject: Inbound = { ...JSON.parse(JSON.stringify(defaultValues[type] ?? {})), ...(json ?? {}) }
+  // rewrites the defaults the next one starts from. The clone is annotated
+  // because spreading JSON.parse's `any` would make the literal `any` too and
+  // stop TypeScript from checking it.
+  const base: Inbound = JSON.parse(JSON.stringify(defaultValues[type] ?? {}))
+  const defaultObject: Inbound = { ...base, ...(json ?? {}) }
   return defaultObject
 }

--- a/frontend/src/types/outbounds.ts
+++ b/frontend/src/types/outbounds.ts
@@ -269,7 +269,10 @@ const defaultValues: Record<OutType, Outbound> = {
 export function createOutbound<T extends Outbound>(type: string,json?: Partial<T>): Outbound {
   // Deep copy: a shallow spread hands every new outbound the very same nested
   // objects (tls, multiplex, transport, torrc), so filling in one form rewrites
-  // the defaults the next one starts from.
-  const defaultObject: Outbound = { ...JSON.parse(JSON.stringify(defaultValues[type] ?? {})), ...(json || {}) }
+  // the defaults the next one starts from. The clone is annotated because
+  // spreading JSON.parse's `any` would make the literal `any` too and stop
+  // TypeScript from checking it.
+  const base: Outbound = JSON.parse(JSON.stringify(defaultValues[type] ?? {}))
+  const defaultObject: Outbound = { ...base, ...(json || {}) }
   return defaultObject
 }

--- a/frontend/src/types/outbounds.ts
+++ b/frontend/src/types/outbounds.ts
@@ -267,6 +267,9 @@ const defaultValues: Record<OutType, Outbound> = {
 }
 
 export function createOutbound<T extends Outbound>(type: string,json?: Partial<T>): Outbound {
-  const defaultObject: Outbound = { ...defaultValues[type], ...(json || {}) }
+  // Deep copy: a shallow spread hands every new outbound the very same nested
+  // objects (tls, multiplex, transport, torrc), so filling in one form rewrites
+  // the defaults the next one starts from.
+  const defaultObject: Outbound = { ...JSON.parse(JSON.stringify(defaultValues[type] ?? {})), ...(json || {}) }
   return defaultObject
 }

--- a/frontend/src/types/services.ts
+++ b/frontend/src/types/services.ts
@@ -72,6 +72,9 @@ const defaultValues: Record<SrvType, Srv> = {
 }
 
 export function createSrv<T extends Srv>(type: string, json?: Partial<T>): Srv {
-  const defaultObject: Srv = { ...defaultValues[type], ...(json || {}) }
+  // Deep copy: a shallow spread hands every new service the very same nested
+  // servers and users containers, so filling in one form rewrites the defaults
+  // the next one starts from.
+  const defaultObject: Srv = { ...JSON.parse(JSON.stringify(defaultValues[type] ?? {})), ...(json || {}) }
   return defaultObject
 }

--- a/frontend/src/types/services.ts
+++ b/frontend/src/types/services.ts
@@ -74,7 +74,10 @@ const defaultValues: Record<SrvType, Srv> = {
 export function createSrv<T extends Srv>(type: string, json?: Partial<T>): Srv {
   // Deep copy: a shallow spread hands every new service the very same nested
   // servers and users containers, so filling in one form rewrites the defaults
-  // the next one starts from.
-  const defaultObject: Srv = { ...JSON.parse(JSON.stringify(defaultValues[type] ?? {})), ...(json || {}) }
+  // the next one starts from. The clone is annotated because spreading
+  // JSON.parse's `any` would make the literal `any` too and stop TypeScript
+  // from checking it.
+  const base: Srv = JSON.parse(JSON.stringify(defaultValues[type] ?? {}))
+  const defaultObject: Srv = { ...base, ...(json || {}) }
   return defaultObject
 }

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -1235,8 +1235,15 @@ const updateRuleSets = () => {
   const tags = <string[]>[]
   if ((dns.value?.rules?.length ?? 0) > 0) dns.value.rules.forEach((r: any) => { if (r.rule_set) tags.push(...r.rule_set) })
   if ((rules.value?.length ?? 0) > 0) rules.value.forEach((r: any) => { if (r.rule_set) tags.push(...r.rule_set) })
-  if (tags.length > 0) {
-    subJsonExt.value.rule_set = geo.filter((g: any) => tags.includes(g.tag))
+  // The list is rebuilt from the selectors, so anything the operator added by
+  // hand in the JSON editor has to be carried over or a single chip click
+  // silently drops it.
+  const custom = (subJsonExt.value?.rule_set ?? []).filter((rs: any) => !geo.some((g: any) => g.tag == rs.tag))
+  if (tags.length > 0 || custom.length > 0) {
+    subJsonExt.value.rule_set = [
+      ...geo.filter((g: any) => tags.includes(g.tag)),
+      ...custom,
+    ]
   } else {
     delete subJsonExt.value.rule_set
   }

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -1240,10 +1240,15 @@ const updateRuleSets = () => {
   // silently drops it. That editor takes any JSON, so the stored value is not
   // necessarily an array.
   const existing = subJsonExt.value?.rule_set
-  const custom = Array.isArray(existing) ? existing.filter((rs: any) => !geo.some((g: any) => g.tag == rs.tag)) : []
+  const list: any[] = Array.isArray(existing) ? existing : []
+  const byTag = new Map(list.map((rs: any) => [rs.tag, rs]))
+  const custom = list.filter((rs: any) => !geo.some((g: any) => g.tag == rs.tag))
   if (tags.length > 0 || custom.length > 0) {
     subJsonExt.value.rule_set = [
-      ...geo.filter((g: any) => tags.includes(g.tag)),
+      // A catalog entry the operator already edited wins over the catalog --
+      // swapping the jsDelivr URL for a mirror has to survive a chip click.
+      // The trade-off is that later catalog fixes no longer reach them.
+      ...geo.filter((g: any) => tags.includes(g.tag)).map((g: any) => byTag.get(g.tag) ?? g),
       ...custom,
     ]
   } else {

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -1237,8 +1237,10 @@ const updateRuleSets = () => {
   if ((rules.value?.length ?? 0) > 0) rules.value.forEach((r: any) => { if (r.rule_set) tags.push(...r.rule_set) })
   // The list is rebuilt from the selectors, so anything the operator added by
   // hand in the JSON editor has to be carried over or a single chip click
-  // silently drops it.
-  const custom = (subJsonExt.value?.rule_set ?? []).filter((rs: any) => !geo.some((g: any) => g.tag == rs.tag))
+  // silently drops it. That editor takes any JSON, so the stored value is not
+  // necessarily an array.
+  const existing = subJsonExt.value?.rule_set
+  const custom = Array.isArray(existing) ? existing.filter((rs: any) => !geo.some((g: any) => g.tag == rs.tag)) : []
   if (tags.length > 0 || custom.length > 0) {
     subJsonExt.value.rule_set = [
       ...geo.filter((g: any) => tags.includes(g.tag)),

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -991,8 +991,8 @@ const geositeList = [
 ]
 
 const geoList = [
-  { title: "Site-Private", value: "geoip-private" },
-  { title: "IP-Private", value: "geosite-private" },
+  { title: "Site-Private", value: "geosite-private" },
+  { title: "IP-Private", value: "geoip-private" },
   { title: "Site-Ads", value: "geosite-ads" },
   { title: "🇮🇷 Site-Iran", value: "geosite-ir" },
   { title: "🇮🇷 IP-Iran", value: "geoip-ir" },

--- a/util/genLink.go
+++ b/util/genLink.go
@@ -246,6 +246,27 @@ func naiveLink(
 		port, _ := addr["server_port"].(float64)
 		uri := baseUri + toBase64([]byte(fmt.Sprintf("%s:%s@%s:%.0f", username, password, addr["server"].(string), port)))
 		links = append(links, addParams(uri, params, addr["remark"].(string)))
+
+		// The legacy http2:// form above carries no transport, so a client cannot
+		// tell an h2 listener from an h3 one. Emit the plain naive+ form too, one
+		// per network the inbound actually listens on -- an unset network means
+		// both.
+		var schemes []string
+		switch network, _ := inbound["network"].(string); network {
+		case "tcp":
+			schemes = []string{"naive+https"}
+		case "udp":
+			schemes = []string{"naive+quic"}
+		default:
+			schemes = []string{"naive+https", "naive+quic"}
+		}
+		// Userinfo has its own escaping set; QueryEscape would turn a space into
+		// a '+', which reads back as a literal '+' here.
+		userInfo := url.UserPassword(username, password).String()
+		for _, scheme := range schemes {
+			plainUri := fmt.Sprintf("%s://%s@%s:%.0f", scheme, userInfo, addr["server"].(string), port)
+			links = append(links, addParams(plainUri, params, addr["remark"].(string)))
+		}
 	}
 	return links
 }

--- a/util/genLink.go
+++ b/util/genLink.go
@@ -264,8 +264,16 @@ func naiveLink(
 		// a '+', which reads back as a literal '+' here.
 		userInfo := url.UserPassword(username, password).String()
 		for _, scheme := range schemes {
+			// Every link for one address would otherwise carry the same remark and
+			// reach the client as identically named nodes. Only the new ones get a
+			// suffix; the legacy link keeps its bare remark so it stays the same
+			// node for clients that already have it.
+			suffix := "-h2"
+			if scheme == "naive+quic" {
+				suffix = "-h3"
+			}
 			plainUri := fmt.Sprintf("%s://%s@%s:%.0f", scheme, userInfo, addr["server"].(string), port)
-			links = append(links, addParams(plainUri, params, addr["remark"].(string)))
+			links = append(links, addParams(plainUri, params, addr["remark"].(string)+suffix))
 		}
 	}
 	return links

--- a/util/genLink_test.go
+++ b/util/genLink_test.go
@@ -10,8 +10,10 @@ func TestNaiveLinkSchemesFollowNetwork(t *testing.T) {
 		network string
 		want    []string
 	}{
-		// A listener bound to one network can only be reached over the matching
-		// scheme, so offering the other one would hand out a dead link.
+		// The plain naive+ scheme has to match the listener's network, or the
+		// link is dead. The legacy http2:// form goes out either way, for
+		// clients that parse nothing else -- on a udp-only inbound that one is
+		// dead too, and kept anyway rather than diverging from upstream.
 		{"tcp", []string{"http2://", "naive+https://"}},
 		{"udp", []string{"http2://", "naive+quic://"}},
 
@@ -64,5 +66,30 @@ func TestNaiveLinkEscapesUserinfo(t *testing.T) {
 	const want = "naive+https://a%20b:p%40ss%2Fword@example.com:443"
 	if len(links) != 2 || !strings.HasPrefix(links[1], want) {
 		t.Errorf("got %v, want a link starting with %q", links, want)
+	}
+}
+
+func TestNaiveLinkRemarksDistinguishTransport(t *testing.T) {
+	links := naiveLink(
+		map[string]interface{}{"username": "u", "password": "p"},
+		map[string]interface{}{},
+		[]map[string]interface{}{{
+			"server":      "example.com",
+			"server_port": float64(443),
+			"remark":      "naive-in",
+		}},
+	)
+
+	// Three links for one address, so the plain ones say which transport they
+	// are. The legacy link keeps the bare remark: renaming it would read as a
+	// different node to a client that already has it.
+	want := []string{"#naive-in", "#naive-in-h2", "#naive-in-h3"}
+	if len(links) != len(want) {
+		t.Fatalf("got %d links %v, want %d", len(links), links, len(want))
+	}
+	for i, fragment := range want {
+		if !strings.HasSuffix(links[i], fragment) {
+			t.Errorf("link %d = %q, want suffix %q", i, links[i], fragment)
+		}
 	}
 }

--- a/util/genLink_test.go
+++ b/util/genLink_test.go
@@ -1,0 +1,68 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNaiveLinkSchemesFollowNetwork(t *testing.T) {
+	tests := []struct {
+		network string
+		want    []string
+	}{
+		// A listener bound to one network can only be reached over the matching
+		// scheme, so offering the other one would hand out a dead link.
+		{"tcp", []string{"http2://", "naive+https://"}},
+		{"udp", []string{"http2://", "naive+quic://"}},
+
+		// Unset means sing-box listens on both.
+		{"", []string{"http2://", "naive+https://", "naive+quic://"}},
+	}
+
+	addrs := []map[string]interface{}{{
+		"server":      "example.com",
+		"server_port": float64(443),
+		"remark":      "naive-in",
+	}}
+
+	for _, tt := range tests {
+		name := tt.network
+		if name == "" {
+			name = "unset"
+		}
+		t.Run(name, func(t *testing.T) {
+			inbound := map[string]interface{}{}
+			if tt.network != "" {
+				inbound["network"] = tt.network
+			}
+			links := naiveLink(map[string]interface{}{"username": "u", "password": "p"}, inbound, addrs)
+
+			if len(links) != len(tt.want) {
+				t.Fatalf("got %d links %v, want %d", len(links), links, len(tt.want))
+			}
+			for i, prefix := range tt.want {
+				if !strings.HasPrefix(links[i], prefix) {
+					t.Errorf("link %d = %q, want prefix %q", i, links[i], prefix)
+				}
+			}
+		})
+	}
+}
+
+func TestNaiveLinkEscapesUserinfo(t *testing.T) {
+	links := naiveLink(
+		// A space must survive as %20: '+' would read back as a literal plus.
+		map[string]interface{}{"username": "a b", "password": "p@ss/word"},
+		map[string]interface{}{"network": "tcp"},
+		[]map[string]interface{}{{
+			"server":      "example.com",
+			"server_port": float64(443),
+			"remark":      "naive-in",
+		}},
+	)
+
+	const want = "naive+https://a%20b:p%40ss%2Fword@example.com:443"
+	if len(links) != 2 || !strings.HasPrefix(links[1], want) {
+		t.Errorf("got %v, want a link starting with %q", links, want)
+	}
+}


### PR DESCRIPTION
Picks up what is left of [s-ui v1.5.5](https://github.com/alireza0/s-ui/releases/tag/v1.5.5) after dropping what this fork already has or solves differently, plus what reviewing those changes turned up next to them.

## Ported

- **naive links follow the inbound's network** ([#1211](https://github.com/alireza0/s-ui/issues/1211)) — the legacy base64 `http2://` link carries no transport, so a client cannot tell an h2 listener from an h3 one. `naive+https` / `naive+quic` are emitted alongside it, both when the network is unset. Userinfo goes through `url.UserPassword` rather than upstream's `QueryEscape`, which writes a space as `+` and reads back as a literal plus.
- **ShadowTLS handshake port** ([#1215](https://github.com/alireza0/s-ui/issues/1215)) — `handshake.server_port` has no sing-box default, so an inbound created without editing that field failed to start. Seeds 443.
- **`updateRuleSets` no longer drops hand-written rule-sets** — the rebuild only knew the built-in catalog, so a rule-set added in the JSON editor vanished on the next chip edit. Fixed upstream inside [#1208](https://github.com/alireza0/s-ui/issues/1208), whose selector work this repo's rewritten settings page does not otherwise share.
- **swapped Private rule-set values** — Site-Private carried `geoip-private` and vice versa, so those chips routed the opposite of their label. Inherited from upstream, which fixed it while extracting the catalog.

## Found while reviewing the above

- **`create*` handed out shared nested objects** — `createInbound` and its four siblings spread `defaultValues[type]` one level deep, so every object and array below the top level stayed shared with the module-level template, and the forms write straight into those. Give a ShadowTLS inbound a handshake port of 8443 and the next new one opened on 8443, not the 443 seeded above; the same leak covered vless/vmess/trojan `transport`, anytls `padding_scheme`, outbound `tls`/`multiplex`/`torrc`, wireguard `address`, warp `peers`, DNS `tls`/`headers`/`path`, ssm-api `servers` and ocm `users` — 15 sites. The default is deep-copied before the spread now, and the clone is annotated so spreading `JSON.parse`'s `any` does not silence the check on the literal.
- **the three naive links per address were named alike** — every link took the address remark verbatim, so a client listed two or three identically named nodes with no way to tell the transport apart. The plain links get `-h2` / `-h3`; the legacy one keeps its bare remark, because renaming it would read as a different node to a client that already has the subscription.
- **edits to built-in rule-sets were reset by a chip click** — the carry-over kept entries whose tag is not in the built-in catalog, but rebuilt every catalog entry from the hard-coded list, so swapping the `geosite-cn` jsDelivr URL for an internal mirror lasted until the next chip click. An existing entry now wins over the catalog copy of the same tag. Trade-off: a later fix to a catalog URL no longer reaches a panel that already has that entry, and deleting it in the JSON editor is the way back to the default.
- **a non-array `rule_set` crashed the chip setters** — carrying hand-written entries over means reading `subJsonExt.rule_set` back, and `??` only covers null and undefined. The JSON editor accepts any shape, so a stored `"rule_set": {}` turned the next chip click into a `TypeError` inside a computed setter and lost the edit.
- **`network` was missing from the `Naive` interface** — the inbound form has always offered TCP/UDP/both and the link generator now branches on the value, but the interface never declared it; the form takes its data prop as `any`, so nothing ever complained.

## Deliberately skipped

- **db lock** ([#1209](https://github.com/alireza0/s-ui/issues/1209)) — `_txlock=immediate` is already on main.
- **manual stats refresh** ([#1205](https://github.com/alireza0/s-ui/issues/1205)) — upstream makes its 10s poll opt-in; the stats modal here is websocket-push and never polled.
- **dependency bumps** — sing-box 1.13.18, sing 0.8.12, grpc, tailscale, cronet-go. Dependabot has #91 and #92 open and will carry the rest.
- **JSON-sub route selectors** ([#1208](https://github.com/alireza0/s-ui/issues/1208)) and **ruleset presets** ([#1216](https://github.com/alireza0/s-ui/issues/1216)) — feature work, and the rewritten frontend shares no components with upstream's, so both need writing from scratch rather than porting.
- **the legacy `http2://` link on a udp-only inbound** — nothing is listening for it there, so it is a dead entry in the subscription. Dropping it would diverge from upstream and would leave a client that parses nothing but the legacy form with no link at all, so it stays; the test comment that claimed otherwise is corrected.

## Testing

`util/genLink_test.go` covers the scheme set per network, the userinfo escaping and the per-transport remarks. `go vet ./...`, `go build` (full build tags, CGO), `go test ./util/...`, `vue-tsc --noEmit` and `vite build` all pass locally.

The frontend has no test runner, so the two frontend behaviours were checked out of tree instead. Deep copy: the five `types/*.ts` modules were bundled standalone and each of the 15 sites exercised before and after — all 15 leak without the fix, none with it. Rule-set merge: the eight interesting combinations of hand-edited, hand-written and catalog entries were run against a copy of the function body. Neither check is committed, so nothing guards a regression, and `updateRuleSets` is still worth a manual pass on a real panel.
