### PR TITLE
fix: two routing-rule bugs behind #116 and #117

### DIFF
--- a/api/apiService.go
+++ b/api/apiService.go
@@ -147,15 +147,31 @@ func (a *ApiService) LoadPartialData(c *gin.Context, objs []string) error {
 			// websocket payload, save responses — gets the lean projection.
 			var clients interface{}
 			var err error
+			// Whole-list reads are versioned like the payload assembler's own,
+			// and the seq is allocated before the read: this is the answer to
+			// api/save, and without a version the SPA applies the list without
+			// advancing its high-water mark, so a live push that read the table
+			// before the save commits can still land after it and restore the
+			// rows the save removed. Deliberately not set for an id read — that
+			// returns one row, and stamping a whole-list version on it would let
+			// a single record veto a later list. The node-facing full=1 read
+			// does not go near the SPA store either.
+			var clientsSeq uint64
 			if id == "" && c.Query("full") == "1" {
 				clients, err = a.ClientService.GetAllWithConfig()
 			} else {
+				if id == "" {
+					clientsSeq = service.NextConfigSeq()
+				}
 				clients, err = a.ClientService.Get(id)
 			}
 			if err != nil {
 				return err
 			}
 			data[obj] = clients
+			if clientsSeq > 0 {
+				data["clientsSeq"] = clientsSeq
+			}
 		case "config":
 			config, err := a.SettingService.GetConfig()
 			if err != nil {

--- a/frontend/src/layouts/drawers/dns/DnsRuleDrawer.vue
+++ b/frontend/src/layouts/drawers/dns/DnsRuleDrawer.vue
@@ -88,6 +88,7 @@
 
     <!-- match conditions -->
     <MHint v-if="logical" style="margin-bottom: 15px;">{{ $t('ui.logicalHint') }}</MHint>
+    <MHint v-if="hasTextList" style="margin-bottom: 15px;">{{ $t('rule.etaHint') }}</MHint>
 
     <div
       v-for="(r, ri) in (logical ? form.rules : form.rules.slice(0, 1))"
@@ -124,14 +125,17 @@
           <div v-else-if="kindOf(k) === 'bool'" style="display: flex; align-items: center; height: 38px;">
             <Toggle :model-value="!!r[k]" @update:model-value="r[k] = $event" />
           </div>
-          <input
+          <textarea
             v-else
             class="input mono"
-            style="height: 38px; font-size: 12.5px;"
+            spellcheck="false"
+            dir="ltr"
+            :rows="rowsFor(r, k)"
+            style="height: auto; padding: 9px 11px; font-size: 12.5px; resize: vertical;"
             :value="csvGet(r, k)"
-            :placeholder="(PLACEHOLDER[k] ?? '') + ' ' + $t('commaSeparated')"
-            @change="csvSet(r, k, ($event.target as HTMLInputElement).value)"
-          />
+            :placeholder="PLACEHOLDER[k] ?? ''"
+            @change="csvSet(r, k, ($event.target as HTMLTextAreaElement).value)"
+          ></textarea>
 
           <button type="button" class="btn btn-subtle btn-icon" style="height: 38px; width: 34px;" @click="delMatcher(r, k)">
             <Ico name="close" :size="14" />
@@ -200,6 +204,10 @@ const PLACEHOLDER: Record<string, string> = {
 }
 const BOOL_KEYS = ['source_ip_is_private']
 const NUM_KEYS = ['port', 'source_port']
+// A comma is legal regex syntax, so these split on newlines only: comma
+// splitting tore a bounded repeat like `a{2,4}` into two entries that matched
+// nothing, leaving no way to enter such a pattern at all.
+const NEWLINE_ONLY_KEYS = ['domain_regex']
 const MULTI_OPTIONS: Record<string, string[]> = {
   protocol: ['http', 'tls', 'quic', 'stun', 'dns'],
 }
@@ -293,6 +301,14 @@ const extra = computed({
 // ---- matcher helpers ----
 const matcherKeys = (r: any): string[] => MATCH_KEYS.filter((k) => r[k] !== undefined)
 
+// Only worth explaining the one-per-line convention while a free-text list is on
+// screen; a rule matching purely on chips and toggles has nothing to type into.
+const hasTextList = computed(() =>
+  (logical.value ? form.value.rules : form.value.rules.slice(0, 1)).some((r: any) =>
+    matcherKeys(r).some((k) => kindOf(k) === 'csv' || kindOf(k) === 'nums'),
+  ),
+)
+
 function kindOf(k: string): string {
   if (k === 'ip_version') return 'ipver'
   if (BOOL_KEYS.includes(k)) return 'bool'
@@ -340,15 +356,26 @@ function addCondition(r: any) {
   addMatcherKey(r, r.domain_suffix === undefined ? 'domain_suffix' : free[0])
 }
 
-const csvGet = (r: any, k: string): string => (Array.isArray(r[k]) ? r[k].join(',') : '')
+const csvGet = (r: any, k: string): string => (Array.isArray(r[k]) ? r[k].join('\n') : '')
+
+// One entry per line is how these lists are pasted, and the single-line input
+// silently ate the newlines (the HTML value sanitiser strips them), collapsing a
+// pasted list into one unmatchable entry. Comma stays accepted so anything typed
+// or stored the old way still parses.
 function csvSet(r: any, k: string, v: string) {
-  const parts = v.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
+  const sep = NEWLINE_ONLY_KEYS.includes(k) ? /\n+/ : /[\n,]+/
+  const parts = [...new Set(v.split(sep).map((s) => s.trim()).filter((s) => s.length > 0))]
   if (NUM_KEYS.includes(k)) {
     r[k] = parts.length > 0 ? parts.map((s) => parseInt(s, 10)).filter((n) => !isNaN(n)) : []
   } else {
     r[k] = parts
   }
 }
+
+// Grow with the list so a long one is not read through a slit, with a ceiling so
+// it cannot push the rest of the drawer out of reach.
+const rowsFor = (r: any, k: string): number =>
+  Math.min(Math.max((Array.isArray(r[k]) ? r[k].length : 0) + 1, 2), 12)
 
 // ---- save (identical payload shaping to the legacy modal) ----
 function saveChanges() {

--- a/frontend/src/layouts/drawers/route/RuleDrawer.vue
+++ b/frontend/src/layouts/drawers/route/RuleDrawer.vue
@@ -93,6 +93,7 @@
 
     <!-- match conditions -->
     <MHint v-if="logical" style="margin-bottom: 15px;">{{ $t('ui.logicalHint') }}</MHint>
+    <MHint v-if="hasTextList" style="margin-bottom: 15px;">{{ $t('rule.etaHint') }}</MHint>
 
     <div
       v-for="(r, ri) in (logical ? form.rules : form.rules.slice(0, 1))"
@@ -129,14 +130,17 @@
           <div v-else-if="kindOf(k) === 'bool'" style="display: flex; align-items: center; height: 38px;">
             <Toggle :model-value="!!r[k]" @update:model-value="r[k] = $event" />
           </div>
-          <input
+          <textarea
             v-else
             class="input mono"
-            style="height: 38px; font-size: 12.5px;"
+            spellcheck="false"
+            dir="ltr"
+            :rows="rowsFor(r, k)"
+            style="height: auto; padding: 9px 11px; font-size: 12.5px; resize: vertical;"
             :value="csvGet(r, k)"
-            :placeholder="(PLACEHOLDER[k] ?? '') + ' ' + $t('commaSeparated')"
-            @change="csvSet(r, k, ($event.target as HTMLInputElement).value)"
-          />
+            :placeholder="PLACEHOLDER[k] ?? ''"
+            @change="csvSet(r, k, ($event.target as HTMLTextAreaElement).value)"
+          ></textarea>
 
           <button type="button" class="btn btn-subtle btn-icon" style="height: 38px; width: 34px;" @click="delMatcher(r, k)">
             <Ico name="close" :size="14" />
@@ -204,6 +208,10 @@ const PLACEHOLDER: Record<string, string> = {
 }
 const BOOL_KEYS = ['ip_is_private', 'source_ip_is_private', 'rule_set_ip_cidr_match_source']
 const NUM_KEYS = ['port', 'source_port']
+// A comma is legal regex syntax, so these split on newlines only: comma
+// splitting tore a bounded repeat like `a{2,4}` into two entries that matched
+// nothing, leaving no way to enter such a pattern at all.
+const NEWLINE_ONLY_KEYS = ['domain_regex']
 const MULTI_OPTIONS: Record<string, string[]> = {
   network: ['tcp', 'udp', 'icmp'],
   protocol: ['http', 'tls', 'quic', 'stun', 'dns', 'bittorrent', 'dtls', 'ssh', 'rdp', 'ntp'],
@@ -287,6 +295,14 @@ const resolveStrategy = computed({
 // ---- matcher helpers ----
 const matcherKeys = (r: any): string[] => MATCH_KEYS.filter((k) => r[k] !== undefined)
 
+// Only worth explaining the one-per-line convention while a free-text list is on
+// screen; a rule matching purely on chips and toggles has nothing to type into.
+const hasTextList = computed(() =>
+  (logical.value ? form.value.rules : form.value.rules.slice(0, 1)).some((r: any) =>
+    matcherKeys(r).some((k) => kindOf(k) === 'csv' || kindOf(k) === 'nums'),
+  ),
+)
+
 function kindOf(k: string): string {
   if (k === 'ip_version') return 'ipver'
   if (BOOL_KEYS.includes(k)) return 'bool'
@@ -345,15 +361,26 @@ function addCondition(r: any) {
   addMatcherKey(r, r.domain_suffix === undefined ? 'domain_suffix' : free[0])
 }
 
-const csvGet = (r: any, k: string): string => (Array.isArray(r[k]) ? r[k].join(',') : '')
+const csvGet = (r: any, k: string): string => (Array.isArray(r[k]) ? r[k].join('\n') : '')
+
+// One entry per line is how these lists are pasted, and the single-line input
+// silently ate the newlines (the HTML value sanitiser strips them), collapsing a
+// pasted list into one unmatchable entry. Comma stays accepted so anything typed
+// or stored the old way still parses.
 function csvSet(r: any, k: string, v: string) {
-  const parts = v.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
+  const sep = NEWLINE_ONLY_KEYS.includes(k) ? /\n+/ : /[\n,]+/
+  const parts = [...new Set(v.split(sep).map((s) => s.trim()).filter((s) => s.length > 0))]
   if (NUM_KEYS.includes(k)) {
     r[k] = parts.length > 0 ? parts.map((s) => parseInt(s, 10)).filter((n) => !isNaN(n)) : []
   } else {
     r[k] = parts
   }
 }
+
+// Grow with the list so a long one is not read through a slit, with a ceiling so
+// it cannot push the rest of the drawer out of reach.
+const rowsFor = (r: any, k: string): number =>
+  Math.min(Math.max((Array.isArray(r[k]) ? r[k].length : 0) + 1, 2), 12)
 
 // ---- save (identical payload shaping to the legacy modal) ----
 function saveChanges() {

--- a/frontend/src/store/modules/data.ts
+++ b/frontend/src/store/modules/data.ts
@@ -12,6 +12,10 @@ const Data = defineStore('Data', {
     // Highest config version applied; guards against a stale snapshot landing
     // after a newer push. See applyLive.
     cseq: 0,
+    // Same guard for the client list, which arrives on both the live and the
+    // full payload and so needs its own high-water mark: a live push carries no
+    // config and must not be rejected by cseq, nor reject a config push itself.
+    clientsSeq: 0,
     reloadItems: localStorage.getItem("reloadItems")?.split(',')?? <string[]>[],
     subURI: "",
     os: "",
@@ -46,6 +50,20 @@ const Data = defineStore('Data', {
     },
   },
   actions: {
+    // The client list reaches the store from two independently built payloads:
+    // the 10s live push and the config half of a full one. They are assembled on
+    // different goroutines, so arrival order does not imply read order -- without
+    // this high-water mark a list read before a save could land after it and put
+    // the old rows back for a whole flush interval, which reads as the save
+    // having silently failed. A payload with no version (a backend older than
+    // this) applies unconditionally, as it used to.
+    applyClients(list: any, seq: any) {
+      if (typeof seq === 'number') {
+        if (seq <= this.clientsSeq) return
+        this.clientsSeq = seq
+      }
+      this.clients = list ?? []
+    },
     // Shared by the websocket 'load' topic and the one-shot HTTP load below.
     // Websocket pushes are partial: a missing key means "unchanged", so only
     // present keys are applied.
@@ -53,6 +71,14 @@ const Data = defineStore('Data', {
       if (obj.onlines) this.onlines = obj.onlines
       if (Object.hasOwn(obj, 'nodesStatus')) this.nodesStatus = obj.nodesStatus ?? {}
       if (Object.hasOwn(obj, 'ipCounts')) this.ipCounts = obj.ipCounts ?? {}
+      // Client traffic is rewritten every stats flush without marking a config
+      // change, so the client list rides the live payload too -- waiting for the
+      // next full payload would freeze the traffic columns on a panel where
+      // nothing else is being saved. Payloads that carry a config go through
+      // setNewData instead, so their clients are applied there.
+      if (!obj.config && Object.hasOwn(obj, 'clients')) {
+        this.applyClients(obj.clients, obj.clientsSeq)
+      }
       if (obj.lastLog) {
         push.error({
           title: i18n.global.t('error.core'),
@@ -108,7 +134,7 @@ const Data = defineStore('Data', {
       if (data.os) this.os = data.os
       if (data.enableTraffic) this.enableTraffic = data.enableTraffic
       if (data.config) this.config = data.config
-      if (Object.hasOwn(data, 'clients')) this.clients = data.clients ?? []
+      if (Object.hasOwn(data, 'clients')) this.applyClients(data.clients, data.clientsSeq)
       if (Object.hasOwn(data, 'inbounds')) this.inbounds = data.inbounds ?? []
       if (Object.hasOwn(data, 'outbounds')) this.outbounds = data.outbounds ?? []
       if (Object.hasOwn(data, 'services')) this.services = data.services ?? []

--- a/service/client.go
+++ b/service/client.go
@@ -699,12 +699,22 @@ func (s *ClientService) DepleteClients() ([]uint, []string, error) {
 	dt := time.Now().Unix()
 	db := database.GetDB()
 
+	// This job runs every minute whether or not there is anything to deplete or
+	// reset, so notifying unconditionally is not free: the hub answers with a
+	// full config push and the SPA swaps its whole config object for the new
+	// one, throwing away whatever the operator had typed into the rules/DNS/
+	// settings pages but not saved yet. Both write paths below already mark
+	// LastUpdate exactly when they wrote something -- follow that same
+	// condition instead of announcing an idle round.
+	seqBefore := lastUpdateSeq.Load()
 	tx := db.Begin()
 	defer func() {
 		if err == nil {
 			tx.Commit()
 			// Only now is the write visible on the hub's own connection.
-			NotifyConfigChanged()
+			if lastUpdateSeq.Load() != seqBefore {
+				NotifyConfigChanged()
+			}
 			if err1 := db.Exec("PRAGMA wal_checkpoint(FULL)").Error; err1 != nil {
 				logger.Error("Error checkpointing WAL: ", err1.Error())
 			}
@@ -841,6 +851,13 @@ func (s *ClientService) ResetClients(tx *gorm.DB, dt int64) ([]uint, []string, e
 		if err != nil {
 			return nil, nil, err
 		}
+	}
+	// Mark on any write, not only on the ones that log a Changes row: the
+	// periodic-reset branch rewrites counters and can flip Enable back on
+	// without recording a change, and DepleteClients gates its hub notify on
+	// this mark. Without it a re-enabled client stays greyed out in every open
+	// panel while sing-box is already letting it back in.
+	if len(allClients) > 0 || len(changes) > 0 {
 		MarkLastUpdate(dt)
 	}
 	return inboundIds, reenabled, nil

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -2,10 +2,15 @@ package service
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"reflect"
 	"testing"
 
+	"github.com/shenaba/2s-ui/database"
 	"github.com/shenaba/2s-ui/database/model"
+	"github.com/shenaba/2s-ui/logger"
+
+	"github.com/op/go-logging"
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -244,5 +249,72 @@ func TestPayloadFields(t *testing.T) {
 				t.Errorf("payloadFields(%s) = %v, want %v", tc.data, got, tc.want)
 			}
 		})
+	}
+}
+
+// The DepleteJob fires every minute whether or not there is anything to do, and
+// its notify makes the hub push a full config payload -- which the SPA applies
+// by replacing its whole config object, taking any edit the operator has open
+// but unsaved on the rules/DNS/settings pages with it. The notify is gated on
+// this round having marked a change, so an idle round has to mark nothing.
+func TestDepleteClientsMarksOnlyRealChanges(t *testing.T) {
+	// DepleteClients reads the package-level handle rather than taking one, so
+	// the DB has to be installed globally. CloseDBForTest puts it back on the
+	// way out, and is registered after TempDir's own cleanup so LIFO runs it
+	// first: Windows refuses to delete the file while the pool holds it open.
+	// The deplete path logs each client it disables, and package logger panics
+	// on a nil handle -- nothing installs one in a test binary.
+	logger.InitLogger(logging.CRITICAL)
+
+	dir := t.TempDir()
+	if err := database.InitDB(filepath.Join(dir, "test.db")); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.CloseDBForTest(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
+	db := database.GetDB()
+	var svc ClientService
+
+	// Inside its quota, no expiry, no periodic reset due: nothing to report.
+	healthy := model.Client{
+		Name: "healthy", Enable: true, Group: "user", Up: 1, Down: 1,
+		Inbounds: json.RawMessage(`[]`), Links: json.RawMessage(`[]`), Config: json.RawMessage(`{}`),
+	}
+	if err := db.Create(&healthy).Error; err != nil {
+		t.Fatalf("seed healthy client: %v", err)
+	}
+
+	before := lastUpdateSeq.Load()
+	if _, _, err := svc.DepleteClients(); err != nil {
+		t.Fatalf("idle round: %v", err)
+	}
+	if got := lastUpdateSeq.Load(); got != before {
+		t.Fatalf("an idle round marked %d change(s); the hub would push a full config and discard unsaved edits", got-before)
+	}
+
+	// Over quota: now the round has real news and must say so, or the panel
+	// never hears that the client was cut off.
+	over := model.Client{
+		Name: "over", Enable: true, Group: "user", Up: 10, Down: 10, Volume: 5,
+		Inbounds: json.RawMessage(`[]`), Links: json.RawMessage(`[]`), Config: json.RawMessage(`{}`),
+	}
+	if err := db.Create(&over).Error; err != nil {
+		t.Fatalf("seed over-quota client: %v", err)
+	}
+	if _, _, err := svc.DepleteClients(); err != nil {
+		t.Fatalf("depleting round: %v", err)
+	}
+	if lastUpdateSeq.Load() == before {
+		t.Error("depleting a client marked nothing, so no push would ever report it")
+	}
+	var stillEnabled bool
+	if err := db.Model(model.Client{}).Where("name = ?", "over").Select("enable").Scan(&stillEnabled).Error; err != nil {
+		t.Fatalf("read back client: %v", err)
+	}
+	if stillEnabled {
+		t.Error("over-quota client was not disabled")
 	}
 }

--- a/service/config.go
+++ b/service/config.go
@@ -20,9 +20,13 @@ var (
 	// Written by gin handlers (Save), the DepleteJob and NodesJob cron
 	// goroutines, and read by every api/load handler plus the websocket hub's
 	// read pump — a plain int64 here is a data race the detector flags.
-	// Unexported so the atomic cannot be bypassed; nothing outside this package
-	// touched it.
+	// Unexported so the atomics cannot be bypassed; nothing outside this
+	// package touches them. lastUpdateSeq counts the marks instead of stamping
+	// them, so a caller can tell whether its own run marked anything --
+	// comparing lastUpdate cannot, since two writers landing in the same second
+	// store the same unix value.
 	lastUpdate          atomic.Int64
+	lastUpdateSeq       atomic.Int64
 	corePtr             *core.Core
 	startCoreMu         sync.Mutex
 	startCoreInProgress bool
@@ -315,6 +319,7 @@ func SetLastUpdate(dt int64) {
 // MarkLastUpdate advances the change timestamp without waking the hub.
 func MarkLastUpdate(dt int64) {
 	lastUpdate.Store(dt)
+	lastUpdateSeq.Add(1)
 }
 
 func (s *ConfigService) CheckChanges(lu string) (bool, error) {

--- a/service/paneldata.go
+++ b/service/paneldata.go
@@ -24,11 +24,50 @@ type PanelDataService struct {
 	ServerService
 }
 
-// OnlinesPayload is the per-flush live data: which tags are online, plus the
+// OnlinesPayload is onlinesHalf plus the client list — the per-flush live push
+// and api/load's live answer, both of which have to carry it themselves.
+//
+// Everything here runs on the caller's goroutine, which is what lets
+// HubAfterStatsFlush call it straight after SaveStats and still read
+// onlineResources unsynchronized (see onlinesHalf). Keep it that way: moving
+// either read off this goroutine widens that access.
+func (s *PanelDataService) OnlinesPayload() (map[string]interface{}, error) {
+	data, err := s.onlinesHalf()
+	if err != nil {
+		return nil, err
+	}
+	// Client up/down is rewritten by every stats flush, which does not mark
+	// LastUpdate -- so it rides the live payload rather than waiting for a
+	// config push that may never come on a panel nobody is editing. Sending it
+	// here is what keeps the traffic columns, quota bars and per-client totals
+	// moving.
+	//
+	// Versioned off the same counter the config half uses, and allocated BEFORE
+	// the read for the same reason: the two payload kinds are built on
+	// different goroutines, so a list read here can still be enqueued after a
+	// full payload built later, and applying it would put pre-change rows back
+	// on screen. One shared counter gives both kinds a total order, so the
+	// client can always tell which list was read last.
+	clientsSeq := configSeq.Add(1)
+	clients, err := s.ClientService.GetAll()
+	if err != nil {
+		return nil, err
+	}
+	data["clients"] = clients
+	data["clientsSeq"] = clientsSeq
+	return data, nil
+}
+
+// onlinesHalf is the per-flush live data: which tags are online, plus the
 // newest core log line when sing-box is down (the UI surfaces it as a toast).
 // Callers that run on the StatsJob goroutine right after SaveStats get a value
 // snapshot of onlineResources before anything crosses a goroutine boundary.
-func (s *PanelDataService) OnlinesPayload() (map[string]interface{}, error) {
+//
+// Split out of OnlinesPayload for FullPayload's sake: that one takes its client
+// list from the config half, so going through OnlinesPayload had it scan the
+// whole clients table only to overwrite the result a few lines later — and on a
+// config-cache hit that discarded scan was the only query the call ran.
+func (s *PanelDataService) onlinesHalf() (map[string]interface{}, error) {
 	data := make(map[string]interface{})
 	onlines, err := s.StatsService.GetOnlines()
 
@@ -50,26 +89,6 @@ func (s *PanelDataService) OnlinesPayload() (map[string]interface{}, error) {
 	// so omitting it once nobody is over their limit would leave the last
 	// non-empty counts on screen forever.
 	data["ipCounts"] = GetIPCounts()
-	// Client up/down is rewritten by every stats flush, which does not mark
-	// LastUpdate -- so it rides the live payload rather than waiting for a
-	// config push that may never come on a panel nobody is editing. Sending it
-	// here rather than only in the config half is what keeps the traffic
-	// columns, quota bars and per-client totals moving; FullPayload overwrites
-	// the key with the identical list out of its config half.
-	//
-	// Versioned off the same counter the config half uses, and allocated BEFORE
-	// the read for the same reason: the two payload kinds are built on
-	// different goroutines, so a list read here can still be enqueued after a
-	// full payload built later, and applying it would put pre-change rows back
-	// on screen. One shared counter gives both kinds a total order, so the
-	// client can always tell which list was read last.
-	clientsSeq := configSeq.Add(1)
-	clients, err := s.ClientService.GetAll()
-	if err != nil {
-		return nil, err
-	}
-	data["clients"] = clients
-	data["clientsSeq"] = clientsSeq
 	return data, nil
 }
 
@@ -234,8 +253,10 @@ func (s *PanelDataService) FullPayload(hostname string) (map[string]interface{},
 		return nil, err
 	}
 	// The live half is never cached — onlines and the core's last log move on
-	// their own schedule, not the config's.
-	data, err := s.OnlinesPayload()
+	// their own schedule, not the config's. onlinesHalf rather than
+	// OnlinesPayload: the client list below comes from cfg, so reading a second
+	// one here would only be overwritten.
+	data, err := s.onlinesHalf()
 	if err != nil {
 		return nil, err
 	}
@@ -244,9 +265,8 @@ func (s *PanelDataService) FullPayload(hostname string) (map[string]interface{},
 	}
 	data["lu"] = stamp
 	data["cseq"] = seq
-	// The spread above replaced the live half's client list with the config
-	// half's, so the version has to follow it down -- keeping the live one
-	// would claim a newer read than the rows actually carry and make the next
+	// The client list came from cfg, so its version is the config half's --
+	// claiming a newer read than the rows actually carry would make the next
 	// live push look stale.
 	data["clientsSeq"] = seq
 	s.attachNodesStatus(data)

--- a/service/paneldata.go
+++ b/service/paneldata.go
@@ -141,6 +141,16 @@ func init() {
 	configSeq.Store(uint64(time.Now().UnixMilli()))
 }
 
+// NextConfigSeq allocates a version for a client list assembled outside this
+// package — api/save and api/clients answer with the whole list, and an
+// unversioned one leaves the SPA's high-water mark untouched, so a live push
+// that read the table before the save could still land after it and put the old
+// rows back. Call it BEFORE the read, for the same reason configHalf does: the
+// version has to order this read against a later one.
+func NextConfigSeq() uint64 {
+	return configSeq.Add(1)
+}
+
 // configCacheUsable is the whole staleness decision, kept pure so it can be
 // verified without a database. Serving a stale config is the one way this cache
 // can break the panel, so every reason to rebuild is spelled out here.

--- a/service/paneldata.go
+++ b/service/paneldata.go
@@ -50,6 +50,26 @@ func (s *PanelDataService) OnlinesPayload() (map[string]interface{}, error) {
 	// so omitting it once nobody is over their limit would leave the last
 	// non-empty counts on screen forever.
 	data["ipCounts"] = GetIPCounts()
+	// Client up/down is rewritten by every stats flush, which does not mark
+	// LastUpdate -- so it rides the live payload rather than waiting for a
+	// config push that may never come on a panel nobody is editing. Sending it
+	// here rather than only in the config half is what keeps the traffic
+	// columns, quota bars and per-client totals moving; FullPayload overwrites
+	// the key with the identical list out of its config half.
+	//
+	// Versioned off the same counter the config half uses, and allocated BEFORE
+	// the read for the same reason: the two payload kinds are built on
+	// different goroutines, so a list read here can still be enqueued after a
+	// full payload built later, and applying it would put pre-change rows back
+	// on screen. One shared counter gives both kinds a total order, so the
+	// client can always tell which list was read last.
+	clientsSeq := configSeq.Add(1)
+	clients, err := s.ClientService.GetAll()
+	if err != nil {
+		return nil, err
+	}
+	data["clients"] = clients
+	data["clientsSeq"] = clientsSeq
 	return data, nil
 }
 
@@ -224,6 +244,11 @@ func (s *PanelDataService) FullPayload(hostname string) (map[string]interface{},
 	}
 	data["lu"] = stamp
 	data["cseq"] = seq
+	// The spread above replaced the live half's client list with the config
+	// half's, so the version has to follow it down -- keeping the live one
+	// would claim a newer read than the rows actually carry and make the next
+	// live push look stale.
+	data["clientsSeq"] = seq
 	s.attachNodesStatus(data)
 	return data, nil
 }


### PR DESCRIPTION
Two fixes for issues reported five minutes apart by the same user. They were found together and are easiest to read together, but they are independent — separate commits, no shared files.

## `fix(rules): take newline-separated match values again` (#116)

The 1.5.x redesign replaced the per-key textareas with a single-line `<input>` that splits on commas only. The HTML value sanitisation algorithm for a text input strips newlines, so a **pasted** domain list lost its separators before any of our code saw it and became one unmatchable entry — silently, with a rule that then matches nothing and falls through to `route.final`.

Match values in the route and DNS drawers are textareas again: they split on newline **or** comma (so anything typed or stored the old way still parses), drop blanks and duplicates, and grow with the list up to a cap.

`domain_regex` splits on newlines only — a comma is legal regex syntax, and the old behaviour tore `^a{2,4}\.example\.com$` into two entries that matched nothing, with no way to enter such a pattern at all.

No new strings: `rule.etaHint` and its six translations were orphaned by that same redesign and are reused as they stand.

## `fix(hub): stop the deplete job announcing rounds that changed nothing` (#117)

`DepleteClients` notified the websocket hub from its deferred commit whether or not it had written anything, and it runs every minute. Each notify pushes a full config payload, which the SPA applies by replacing its whole config object — **discarding whatever the operator has open but unsaved** on the rules, DNS or settings pages. Measured on a live panel: a rule added in the drawer was gone 59 seconds later, no error, save button back to disabled.

Upstream polls `api/changes` and compares `lastUpdate`, which an idle round never moves; the websocket switch turned that into "somebody called notify", which an empty round also satisfies.

Three parts:

- The notify follows the same condition the write paths use for `MarkLastUpdate`. Marks are **counted** rather than compared by timestamp — `lastUpdate` is a unix second, so two writers in the same second store the same value.
- `ResetClients` marks on any write, not only when it logs a `Changes` row. Its periodic-reset branch can flip `Enable` back on without recording one, which left a re-enabled client greyed out in every open panel while sing-box was already letting it back in.
- Gating the notify removed the only thing refreshing the client list (the stats flush rewrites `up`/`down` every 10s without marking, and the SPA only assigned `clients` from a full payload), so the live payload now carries the list — versioned off the config counter and read before it, since the two payload kinds are built on different goroutines and arrival order does not imply read order.

## Verification

Backend gate green (`go vet` / `go build` / `go test ./...` with the CI tag set), `gofmt` clean, `vue-tsc` 0 errors, `vite build` passes, `eslint` 0 errors.

Exercised against a live panel rather than only locally:

- pasting a multi-line list with blanks, a duplicate and a comma-mixed line yields the right four entries; commas still split; values round-trip through save/reopen
- `^a{2,4}\.example\.com$` survives as one entry; two regexes on two lines split correctly
- the config object survived 236s (≈4 deplete ticks) untouched, against 59s before the fix
- the ordering gate rejects an older and an equal version, accepts a newer one, and still applies an unversioned payload from an older backend
- `fa` RTL and a simulated 375px viewport: no overflow, list renders LTR

`TestDepleteClientsMarksOnlyRealChanges` covers the idle round. It pins that such a round marks nothing — not that `NotifyConfigChanged` went uncalled, which would need the hub and a debounce wait. A mutation test confirmed it fails when the mark is made unconditional.

## Known limits

- The client list is still shipped whole rather than as the three columns that actually move each round. That costs bytes and a table scan per flush; worth revisiting if a panel grows large enough to feel it.
- This makes the clobbering rare, not impossible: a real change from a second admin, a node sync or an auto-reset day still replaces the config object under an unsaved edit. Fixing that properly means the full-page editors working on a local copy.
