### PR TITLE
fix: login guard follow-ups, plus start-up migrations and backup/import repairs

### DIFF
--- a/api/apiService.go
+++ b/api/apiService.go
@@ -319,9 +319,13 @@ func (a *ApiService) Login(c *gin.Context) {
 	loginUser, err := a.UserService.Login(username, c.Request.FormValue("pass"), c.Request.FormValue("code"), remoteIP)
 	if errors.Is(err, service.ErrTwoFaRequired) {
 		// The password matched and no second factor was attempted, so this is a
-		// prompt rather than a failed login. Counting it would make every real
-		// 2FA login consume one failure before the user can enter a code, cutting
-		// the configured budget roughly in half after any typo or abandoned form.
+		// prompt rather than a failed login: counting it as one would make every
+		// real 2FA login consume a failure before the user can enter a code,
+		// cutting the configured budget roughly in half after any typo or
+		// abandoned form. It is metered on its own far larger budget instead --
+		// it has already paid for a bcrypt comparison, and leaving that unmetered
+		// would let whoever holds a leaked password drive it without limit.
+		a.LoginGuardService.RecordPrompt(remoteIP)
 		// Written out rather than sent through jsonMsg because this is not an
 		// error to report: an empty msg is what keeps httputil.ts from raising
 		// a red "failed" toast over what is really the next step of the form.

--- a/api/login_test.go
+++ b/api/login_test.go
@@ -54,23 +54,119 @@ func TestTwoFaPromptDoesNotConsumeFailureBudget(t *testing.T) {
 		return response
 	}
 
+	// The failure budget is what a real user needs to type a code with, so the
+	// prompt must not touch it. Scope names mirror service's own constants,
+	// which are unexported.
+	failureRows := func() int64 {
+		var n int64
+		if err := database.GetDB().Model(&model.LoginAttempt{}).
+			Where("scope in ?", []string{"ip", "user"}).Count(&n).Error; err != nil {
+			t.Fatalf("count failure rows: %v", err)
+		}
+		return n
+	}
+	promptRows := func() int64 {
+		var n int64
+		if err := database.GetDB().Model(&model.LoginAttempt{}).
+			Where("scope = ?", "prompt").Count(&n).Error; err != nil {
+			t.Fatalf("count prompt rows: %v", err)
+		}
+		return n
+	}
+
 	prompt := request("")
 	if !strings.Contains(prompt.Body.String(), `"twoFa":true`) {
 		t.Fatalf("missing 2fa prompt: %s", prompt.Body.String())
 	}
-	var attempts int64
-	if err := database.GetDB().Model(&model.LoginAttempt{}).Count(&attempts).Error; err != nil {
-		t.Fatalf("count attempts: %v", err)
+	if got := failureRows(); got != 0 {
+		t.Fatalf("2fa prompt spent %d rows of the failure budget, want 0", got)
 	}
-	if attempts != 0 {
-		t.Fatalf("2fa prompt created %d limiter rows, want 0", attempts)
+	// ...but it is metered, or it would be an unbounded bcrypt comparison for
+	// whoever holds a leaked password.
+	if got := promptRows(); got != 1 {
+		t.Fatalf("2fa prompt created %d prompt rows, want 1", got)
 	}
 
 	request("000000")
-	if err := database.GetDB().Model(&model.LoginAttempt{}).Count(&attempts).Error; err != nil {
-		t.Fatalf("count failed-code attempts: %v", err)
+	if got := failureRows(); got != 2 {
+		t.Errorf("wrong 2fa code created %d failure rows, want IP and username rows", got)
 	}
-	if attempts != 2 {
-		t.Errorf("wrong 2fa code created %d limiter rows, want IP and username rows", attempts)
+}
+
+// The prompt budget is a ceiling, not a tight limit: it has to outlast anything
+// a real two-step login does, and still stop before the panel will burn bcrypt
+// comparisons forever.
+func TestTwoFaPromptEventuallyRefuses(t *testing.T) {
+	logger.InitLogger(logging.ERROR)
+	dir := t.TempDir()
+	if err := database.InitDB(filepath.Join(dir, "prompt.db")); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.CloseDBForTest(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
+
+	users := service.UserService{}
+	if err := users.UpdateFirstUser("admin", "correct-password"); err != nil {
+		t.Fatalf("set password: %v", err)
+	}
+	if err := database.GetDB().Model(&model.User{}).
+		Where("username = ?", "admin").Update("two_fa_secret", "!").Error; err != nil {
+		t.Fatalf("enable test 2fa: %v", err)
+	}
+
+	// Every prompt costs a bcrypt comparison, so shrink the budget rather than
+	// spending the shipped one -- the property under test is the ratio to the
+	// failure budget, not the shipped number.
+	settings := service.SettingService{}
+	if _, err := settings.GetAllSetting(); err != nil {
+		t.Fatalf("materialise settings: %v", err)
+	}
+	if err := database.GetDB().
+		Exec(`UPDATE settings SET value = ? WHERE key = ?`, "1", "loginMaxFailures").Error; err != nil {
+		t.Fatalf("shrink failure budget: %v", err)
+	}
+	maxFailures, _, _, err := settings.GetLoginGuard()
+	if err != nil {
+		t.Fatalf("read login guard settings: %v", err)
+	}
+
+	gin.SetMode(gin.TestMode)
+	a := ApiService{}
+	prompt := func() string {
+		form := url.Values{"user": {"admin"}, "pass": {"correct-password"}}
+		req := httptest.NewRequest("POST", "/api/login", strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		req.RemoteAddr = "203.0.113.7:1234"
+		response := httptest.NewRecorder()
+		context, _ := gin.CreateTestContext(response)
+		context.Request = req
+		a.Login(context)
+		return response.Body.String()
+	}
+
+	allowed := 0
+	refused := false
+	for i := 0; i < maxFailures*100; i++ {
+		body := prompt()
+		if strings.Contains(body, "too many failed attempts") {
+			refused = true
+			break
+		}
+		if !strings.Contains(body, `"twoFa":true`) {
+			t.Fatalf("prompt %d answered unexpectedly: %s", i+1, body)
+		}
+		allowed++
+	}
+	if !refused {
+		t.Fatalf("the prompt path never ran out of budget after %d prompts", allowed)
+	}
+	// Strictly larger than the failure budget, or a real two-step login would be
+	// rationed by the same number that rations wrong passwords -- which is the
+	// thing this scope exists to stop.
+	if allowed <= maxFailures {
+		t.Errorf("only %d prompts allowed, want more than the %d-failure budget", allowed, maxFailures)
 	}
 }

--- a/api/utils.go
+++ b/api/utils.go
@@ -18,17 +18,42 @@ type Msg struct {
 	Obj     interface{} `json:"obj"`
 }
 
+// generatedProxyPeers covers the usual generated-nginx case, where the vhost
+// dials the panel on loopback. It is not the whole story -- see
+// generatedProxyPeer.
 var generatedProxyPeers = []netip.Prefix{
 	netip.MustParsePrefix("127.0.0.0/8"),
 	netip.MustParsePrefix("::1/128"),
 }
 
+// generatedProxyPeer is the extra peer to trust when webListen names a concrete
+// address: service/acme.go's upstreamAddr only falls back to loopback for an
+// empty or wildcard listen, so the generated vhost dials the panel's own bind
+// address and nginx reaches it from there. Without this the vhost's own
+// X-Forwarded-For is discarded and every login is attributed to that address --
+// the last-login column shows it for everybody and the limiter's per-address
+// budget becomes one budget for the whole panel.
+func generatedProxyPeer(listen string) (netip.Prefix, bool) {
+	host := strings.Trim(strings.TrimSpace(listen), "[]")
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		// Wildcard listens are dialled on loopback, already covered above.
+		return netip.Prefix{}, false
+	}
+	addr, err := netip.ParseAddr(host)
+	if err != nil {
+		return netip.Prefix{}, false
+	}
+	addr = addr.Unmap()
+	return netip.PrefixFrom(addr, addr.BitLen()), true
+}
+
 // getRemoteIp identifies the caller. X-Forwarded-For is accepted only when the
-// immediate peer is trusted: the generated nginx is implicitly trusted on
-// loopback, while operators of an external proxy configure its IP/CIDR through
-// webTrustedProxies. Tying this to webNginx alone made custom nginx/Caddy/tunnel
-// deployments record the proxy as every user's IP; trusting every peer when
-// that switch was set let direct callers forge a fresh limiter identity.
+// immediate peer is trusted: the generated nginx is implicitly trusted on the
+// address it dials the panel at, while operators of an external proxy configure
+// its IP/CIDR through webTrustedProxies. Tying this to webNginx alone made
+// custom nginx/Caddy/tunnel deployments record the proxy as every user's IP;
+// trusting every peer when that switch was set let direct callers forge a fresh
+// limiter identity.
 func getRemoteIp(c *gin.Context) string {
 	var settingService service.SettingService
 	trusted, err := settingService.GetWebTrustedProxies()
@@ -40,6 +65,11 @@ func getRemoteIp(c *gin.Context) string {
 		logger.Warning("read reverse-proxy setting:", err)
 	} else if behindProxy {
 		trusted = append(trusted, generatedProxyPeers...)
+		if listen, err := settingService.GetListen(); err != nil {
+			logger.Warning("read panel listen address:", err)
+		} else if peer, ok := generatedProxyPeer(listen); ok {
+			trusted = append(trusted, peer)
+		}
 	}
 	return clientIP(c.Request.RemoteAddr, c.GetHeader("X-Forwarded-For"), trusted)
 }

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -5,6 +5,54 @@ import (
 	"testing"
 )
 
+// The generated vhost dials the panel at webListen when that names a concrete
+// address (service/acme.go's upstreamAddr), so loopback alone is not the whole
+// set of peers the panel's own nginx can arrive from.
+func TestGeneratedProxyPeerFollowsWebListen(t *testing.T) {
+	cases := []struct {
+		name   string
+		listen string
+		want   string
+	}{
+		{"empty listen is dialled on loopback", "", ""},
+		{"v4 wildcard is dialled on loopback", "0.0.0.0", ""},
+		{"v6 wildcard is dialled on loopback", "::", ""},
+		{"bracketed v6 wildcard", "[::]", ""},
+		{"not an address", "eth0", ""},
+		{"concrete v4 bind", "10.0.0.5", "10.0.0.5/32"},
+		{"concrete v6 bind", "2001:db8::5", "2001:db8::5/128"},
+		{"bracketed v6 bind", "[2001:db8::5]", "2001:db8::5/128"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prefix, ok := generatedProxyPeer(tc.listen)
+			if tc.want == "" {
+				if ok {
+					t.Errorf("generatedProxyPeer(%q) = %v, want no extra peer", tc.listen, prefix)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("generatedProxyPeer(%q) returned no peer, want %s", tc.listen, tc.want)
+			}
+			if got := prefix.String(); got != tc.want {
+				t.Errorf("generatedProxyPeer(%q) = %q, want %q", tc.listen, got, tc.want)
+			}
+		})
+	}
+
+	// The property that matters: with the panel bound to a concrete address,
+	// the header its own nginx sets is honoured rather than discarded.
+	peer, ok := generatedProxyPeer("10.0.0.5")
+	if !ok {
+		t.Fatal("concrete bind produced no peer")
+	}
+	trusted := append(append([]netip.Prefix{}, generatedProxyPeers...), peer)
+	if got := clientIP("10.0.0.5:5000", "203.0.113.7", trusted); got != "203.0.113.7" {
+		t.Errorf("clientIP() = %q, want the forwarded client", got)
+	}
+}
+
 func TestClientIPTrustsOnlyConfiguredProxyChain(t *testing.T) {
 	custom := []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")}
 	cases := []struct {

--- a/app/app.go
+++ b/app/app.go
@@ -3,6 +3,7 @@ package app
 import (
 	"log"
 
+	"github.com/shenaba/2s-ui/cmd/migration"
 	"github.com/shenaba/2s-ui/config"
 	"github.com/shenaba/2s-ui/core"
 	"github.com/shenaba/2s-ui/cronjob"
@@ -33,6 +34,18 @@ func (a *APP) Init() error {
 	log.Printf("%v %v", config.GetName(), config.GetVersion())
 
 	a.initLog()
+
+	// Data repairs from older releases run here, before the panel opens the
+	// database, on every start-up. The in-panel update button swaps the binary
+	// and restarts the service without ever calling `sui migrate`, so leaving
+	// this to the install script left every panel-updated instance unmigrated.
+	// Each restart path — self-update, systemd, Docker, manual — ends up
+	// executing this binary, so this one call covers all of them. A failure is
+	// logged and start-up continues: a data repair that cannot be applied must
+	// not keep the panel from booting.
+	if err := migration.MigrateDbQuietly(); err != nil {
+		logger.Warning("database migration failed: ", err)
+	}
 
 	err := database.InitDB(config.GetDBPath())
 	if err != nil {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -104,7 +104,10 @@ func ParseCmd() {
 		getPanelURI()
 
 	case "migrate":
-		migration.MigrateDb()
+		if err := migration.MigrateDb(); err != nil {
+			fmt.Println("Migration failed:", err)
+			os.Exit(1)
+		}
 
 	case "setting":
 		err := settingCmd.Parse(os.Args[2:])

--- a/cmd/migration/1_2.go
+++ b/cmd/migration/1_2.go
@@ -259,6 +259,9 @@ func migrateTls(db *gorm.DB) error {
 		tlsConfig[index].Client, _ = json.MarshalIndent(tlsClient, "", "  ")
 	}
 
+	if len(tlsConfig) == 0 {
+		return nil
+	}
 	return db.Save(&tlsConfig).Error
 }
 
@@ -288,6 +291,9 @@ func migrateClients(db *gorm.DB) error {
 			return err
 		}
 		oldClients[index].Inbounds, _ = json.Marshal(inbound_ids)
+	}
+	if len(oldClients) == 0 {
+		return nil
 	}
 	return db.Save(oldClients).Error
 }

--- a/cmd/migration/main.go
+++ b/cmd/migration/main.go
@@ -2,7 +2,7 @@ package migration
 
 import (
 	"fmt"
-	"log"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -39,66 +39,97 @@ func versionBefore(a, b string) bool {
 	return false
 }
 
-func MigrateDb() {
+// MigrateDb applies the one-off data repairs older releases left pending and
+// stamps the database with the running version. Callers must run it before the
+// panel opens the database: the repairs below assume the pre-AutoMigrate
+// schema, exactly as `sui migrate` has always seen it.
+//
+// It reports failures instead of killing the process, because the panel now
+// calls it on every start-up: a data repair that cannot be applied must not
+// keep the panel from booting. Panics become errors for the same reason — the
+// gates below parse whatever version string the database happens to hold.
+// Progress goes to stdout because `sui migrate` is a CLI command whose entire
+// output this is.
+func MigrateDb() error {
+	return migrateDb(os.Stdout)
+}
+
+// MigrateDbQuietly is MigrateDb with the progress lines discarded. The panel
+// calls it on every start-up, where the answer is almost always "already up to
+// date"; printing that would add three lines of untimestamped, unlevelled text
+// to stdout on every restart, on a channel SUI_LOG_LEVEL cannot turn down.
+// Discarded rather than routed to logger: only app.Init initialises logger, so
+// the same call from `sui migrate` would dereference a nil handle.
+func MigrateDbQuietly() error {
+	return migrateDb(io.Discard)
+}
+
+func migrateDb(out io.Writer) (err error) {
 	// void running on first install
 	path := config.GetDBPath()
-	_, err := os.Stat(path)
-	if err != nil {
-		println("Database not found")
-		return
+	if _, statErr := os.Stat(path); statErr != nil {
+		fmt.Fprintln(out, "Database not found")
+		return nil
 	}
 
 	db, err := gorm.Open(sqlite.Open(path))
 	if err != nil {
-		log.Fatal(err)
-		return
+		return err
 	}
 	defer func() {
 		if sqlDB, e := db.DB(); e == nil {
 			_ = sqlDB.Close()
 		}
 	}()
+
 	tx := db.Begin()
+	if tx.Error != nil {
+		return tx.Error
+	}
+	// Registered after the close above so it runs first (defers are LIFO): the
+	// transaction must be settled while the connection is still open. Recovery
+	// lives here rather than in its own defer so a panic cannot reach a commit
+	// with err still nil and write a half-applied migration.
 	defer func() {
-		if err == nil {
-			tx.Commit()
-		} else {
+		if r := recover(); r != nil {
 			tx.Rollback()
+			err = fmt.Errorf("migration panicked: %v", r)
+			return
 		}
+		if err != nil {
+			tx.Rollback()
+			return
+		}
+		err = tx.Commit().Error
 	}()
+
 	currentVersion := config.GetVersion()
 	dbVersion := ""
 	tx.Raw("SELECT value FROM settings WHERE key = ?", "version").Find(&dbVersion)
-	fmt.Println("Current version:", currentVersion, "\nDatabase version:", dbVersion)
+	fmt.Fprintln(out, "Current version:", currentVersion, "\nDatabase version:", dbVersion)
 
 	if currentVersion == dbVersion {
-		fmt.Println("Database is up to date, no need to migrate")
-		return
+		fmt.Fprintln(out, "Database is up to date, no need to migrate")
+		return nil
 	}
 
-	fmt.Println("Start migrating database...")
+	fmt.Fprintln(out, "Start migrating database...")
 
 	// Before 1.2
 	if dbVersion == "" {
-		err = to1_1(tx)
-		if err != nil {
-			log.Fatal("Migration to 1.1 failed: ", err)
-			return
+		if err = to1_1(tx); err != nil {
+			return fmt.Errorf("migration to 1.1 failed: %w", err)
 		}
-		err = to1_2(tx)
-		if err != nil {
-			log.Fatal("Migration to 1.2 failed: ", err)
-			return
+		if err = to1_2(tx); err != nil {
+			return fmt.Errorf("migration to 1.2 failed: %w", err)
 		}
 		dbVersion = "1.2"
 	}
 
 	// Before 1.3
-	if dbVersion[0:3] == "1.2" {
-		err = to1_3(tx)
-		if err != nil {
-			log.Fatal("Migration to 1.3 failed: ", err)
-			return
+	if strings.HasPrefix(dbVersion, "1.2") {
+		if err = to1_3(tx); err != nil {
+			return fmt.Errorf("migration to 1.3 failed: %w", err)
 		}
 	}
 
@@ -109,36 +140,29 @@ func MigrateDb() {
 
 	// Back-fill self-signed TLS public-key pins and rewrite OutJson
 	if versionBefore(dbVersion, "1.5.4") {
-		err = to1_5_1(tx)
-		if err != nil {
-			log.Fatal("Migration to 1.5.1 failed: ", err)
-			return
+		if err = to1_5_1(tx); err != nil {
+			return fmt.Errorf("migration to 1.5.1 failed: %w", err)
 		}
 	}
 
 	// Hash any plaintext admin passwords
 	if versionBefore(dbVersion, "1.5.4") {
-		err = to1_5_2(tx)
-		if err != nil {
-			log.Fatal("Migration to 1.5.2 failed: ", err)
-			return
+		if err = to1_5_2(tx); err != nil {
+			return fmt.Errorf("migration to 1.5.2 failed: %w", err)
 		}
 	}
 
 	// Strip server-only TLS fields leaked into client-facing JSON (#51)
 	if versionBefore(dbVersion, "1.5.7") {
-		err = to1_5_7(tx)
-		if err != nil {
-			log.Fatal("Migration to 1.5.7 failed: ", err)
-			return
+		if err = to1_5_7(tx); err != nil {
+			return fmt.Errorf("migration to 1.5.7 failed: %w", err)
 		}
 	}
 
 	// Set version
-	err = tx.Exec("UPDATE settings SET value = ? WHERE key = ?", currentVersion, "version").Error
-	if err != nil {
-		log.Fatal("Update version failed: ", err)
-		return
+	if err = tx.Exec("UPDATE settings SET value = ? WHERE key = ?", currentVersion, "version").Error; err != nil {
+		return fmt.Errorf("update version failed: %w", err)
 	}
-	fmt.Println("Migration done!")
+	fmt.Fprintln(out, "Migration done!")
+	return nil
 }

--- a/database/backup.go
+++ b/database/backup.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"mime/multipart"
 	"os"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"syscall"
@@ -32,11 +31,23 @@ func GetDb(exclude string) ([]byte, error) {
 		}
 	}
 
-	dir, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	// A unique scratch path rather than a timestamped one: two exports entering
+	// the same second would otherwise share it, and whichever finished first
+	// would delete the file out from under the other.
+	scratch, err := os.CreateTemp(config.GetDBFolderPath(), config.GetName()+"_*.db")
 	if err != nil {
 		return nil, err
 	}
-	dbPath := dir + config.GetName() + "_" + time.Now().Format("20060102-200203") + ".db"
+	dbPath := scratch.Name()
+	// Only the name was wanted; SQLite opens the path itself, and on Windows it
+	// cannot while this handle is still on it.
+	scratch.Close()
+	// Registered here rather than after the open below: CreateTemp has already
+	// made the file, so a failing open would return above the registration and
+	// leave it behind. Still registered before the close for the reason it
+	// always was -- defers are LIFO, so this one runs last, and Windows refuses
+	// to delete a file that is still open.
+	defer os.Remove(dbPath)
 
 	backupDb, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{})
 	if err != nil {
@@ -47,7 +58,6 @@ func GetDb(exclude string) ([]byte, error) {
 			_ = sqlDB.Close()
 		}
 	}()
-	defer os.Remove(dbPath)
 
 	err = backupDb.AutoMigrate(
 		&model.Setting{},
@@ -221,9 +231,51 @@ func ImportDB(file multipart.File) error {
 	old_db, _ := db.DB()
 	old_db.Close()
 
+	// The package-level handle outlives that Close, so any path returning from
+	// here on without reopening leaves GetDB serving a *gorm.DB whose pool is
+	// shut: every later query fails with "sql: database is closed" and the
+	// panel stays up but unusable until someone restarts it by hand. Reopen on
+	// the way out unless the success path below already did.
+	dbReopened := false
+	// Whether config.GetDBPath() still holds the panel's own database. It stops
+	// doing so the moment the upload is moved into place, and only a successful
+	// rollback puts it back -- reopening in between would bring the panel up on
+	// the uploaded data, whose users table is not the operator's.
+	dbPathIsOriginal := true
+	defer func() {
+		if dbReopened {
+			return
+		}
+		if !dbPathIsOriginal {
+			logger.Error("import left the uploaded database in place and could not roll back, not reopening")
+			return
+		}
+		// Only reopen a database that is still there. InitDB creates the file
+		// when it is missing and initUser then seeds admin/admin, so on the path
+		// that leaves nothing behind -- the move below failing and the rollback
+		// failing with it -- reopening would swap the operator's data for an
+		// empty panel anyone can log into. Their database is kept at
+		// fallbackPath there; putting it back is not this defer's job.
+		if _, statErr := os.Stat(config.GetDBPath()); statErr != nil {
+			logger.Error("import left no database in place, not reopening: ", statErr)
+			return
+		}
+		if err := InitDB(config.GetDBPath()); err != nil {
+			logger.Warning("import aborted and reopening the database failed: ", err)
+		}
+	}()
+
 	// Save uploaded file to temporary file
 	_, err = io.Copy(tempFile, file)
 	if err != nil {
+		return common.NewErrorf("Error saving db: %v", err)
+	}
+	// Close before the renames below rather than leaving it to the deferred
+	// Close, which only runs once this function returns: Windows refuses to
+	// rename a file that is still open, so every import on that platform used
+	// to die at "Error moving db file". The defer stays as a safety net for
+	// the early returns above.
+	if err = tempFile.Close(); err != nil {
 		return common.NewErrorf("Error saving db: %v", err)
 	}
 
@@ -239,13 +291,18 @@ func ImportDB(file multipart.File) error {
 
 	// Backup the current database for fallback
 	fallbackPath := fmt.Sprintf("%s.backup", config.GetDBPath())
-	// Remove the existing fallback file (if any)
-	_, err = os.Stat(fallbackPath)
-	if err == nil {
-		errRemove := os.Remove(fallbackPath)
-		if errRemove != nil {
-			return common.NewErrorf("Error removing existing fallback db file: %v", errRemove)
+	// An existing one here is not stale scratch. An earlier import that could
+	// not roll back deliberately leaves the operator's database at this path and
+	// names it in the error it returns, and retrying the import is the natural
+	// reaction to that failure -- so deleting it, which is what this used to do,
+	// would destroy the last copy on exactly the path that was trying to save
+	// it. Archive it under a dated name instead and say where it went.
+	if _, statErr := os.Stat(fallbackPath); statErr == nil {
+		archived := fallbackPath + "." + time.Now().Format("20060102-150405")
+		if errRename := os.Rename(fallbackPath, archived); errRename != nil {
+			return common.NewErrorf("Error archiving the database an earlier failed import left at %s: %v", fallbackPath, errRename)
 		}
+		logger.Warning("a database preserved by an earlier failed import was archived at ", archived)
 	}
 	// Move the current database to the fallback location
 	err = os.Rename(config.GetDBPath(), fallbackPath)
@@ -253,29 +310,51 @@ func ImportDB(file multipart.File) error {
 		return common.NewErrorf("Error backing up temporary db file: %v", err)
 	}
 
-	// Remove the temporary file before returning
-	defer os.Remove(fallbackPath)
+	// Removed only once the import has actually taken. On the two paths below
+	// where restoring it failed, this file is the operator's last copy of their
+	// data, and deleting it here would turn a failed rename into an
+	// unrecoverable one.
+	importDone := false
+	defer func() {
+		if importDone {
+			os.Remove(fallbackPath)
+		}
+	}()
 
 	// Move temp to DB path
 	err = os.Rename(tempPath, config.GetDBPath())
 	if err != nil {
 		errRename := os.Rename(fallbackPath, config.GetDBPath())
 		if errRename != nil {
-			return common.NewErrorf("Error moving db file and restoring fallback: %v", errRename)
+			return common.NewErrorf("Error moving db file and restoring fallback: %v -- the original database is kept at %s", errRename, fallbackPath)
 		}
 		return common.NewErrorf("Error moving db file: %v", err)
 	}
+	dbPathIsOriginal = false
 
-	// Migrate DB
-	migration.MigrateDb()
-	err = InitDB(config.GetDBPath())
+	// Migrate DB. A failed migration leaves the imported file half-repaired,
+	// so restore the fallback instead of booting on it.
+	err = migration.MigrateDb()
+	if err == nil {
+		err = InitDB(config.GetDBPath())
+	}
 	if err != nil {
+		// InitDB opens the pool before it can fail in AutoMigrate or initUser,
+		// and the rollback below renames over that very path -- which Windows
+		// refuses while this process still holds it open, making the rollback
+		// impossible rather than merely unlikely. Release it first.
+		if sqlDB, e := db.DB(); e == nil {
+			_ = sqlDB.Close()
+		}
 		errRename := os.Rename(fallbackPath, config.GetDBPath())
 		if errRename != nil {
-			return common.NewErrorf("Error migrating db and restoring fallback: %v", errRename)
+			return common.NewErrorf("Error migrating db and restoring fallback: %v -- the original database is kept at %s", errRename, fallbackPath)
 		}
+		dbPathIsOriginal = true
 		return common.NewErrorf("Error migrating db: %v", err)
 	}
+	dbReopened = true
+	importDone = true
 
 	// Restart app
 	err = SendSighup()

--- a/database/backup_test.go
+++ b/database/backup_test.go
@@ -1,0 +1,99 @@
+package database
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/shenaba/2s-ui/config"
+	"github.com/shenaba/2s-ui/database/model"
+	"github.com/shenaba/2s-ui/logger"
+
+	"github.com/op/go-logging"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+// ImportDB closes the connection pool before it starts renaming files, and the
+// package-level handle outlives that close. A failure path that returns without
+// reopening therefore leaves GetDB serving a *gorm.DB whose pool is shut: every
+// later query fails with "sql: database is closed" and the panel stays up but
+// unusable until someone restarts it by hand.
+//
+// The import below fails in the migration, which is also what pins the temp
+// file being closed before the renames: Windows cannot rename an open file, so
+// without that close this fails at "Error moving db file" instead and never
+// reaches the migration at all.
+//
+// It deliberately stops at a failing import. The success path ends in
+// SendSighup, which on Windows kills the current process — it would take the
+// test binary down with it.
+func TestImportDBKeepsPoolUsableWhenImportFails(t *testing.T) {
+	// ImportDB reports several of its recovery decisions through logger, whose
+	// handle is nil until something initialises it -- app.Init is the only
+	// caller that does, so a test reaching one of those paths panics instead of
+	// failing.
+	logger.InitLogger(logging.ERROR)
+	dir := t.TempDir()
+	t.Setenv("SUI_DB_FOLDER", dir)
+
+	if err := InitDB(config.GetDBPath()); err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	defer CloseDBForTest()
+
+	// Marker row, so a passing pool check cannot be satisfied by the import.
+	if err := GetDB().Exec("INSERT INTO settings (key, value) VALUES (?, ?)", "test_marker", "original").Error; err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	// A valid SQLite file the migration cannot apply: the version gates it into
+	// to1_5_7, but inbounds has no `addrs` column for it to rewrite.
+	badPath := filepath.Join(dir, "unmigratable.db")
+	bad, err := gorm.Open(sqlite.Open(badPath), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open backup fixture: %v", err)
+	}
+	for _, stmt := range []string{
+		"CREATE TABLE settings (id INTEGER PRIMARY KEY AUTOINCREMENT, key TEXT UNIQUE, value TEXT)",
+		"INSERT INTO settings (key, value) VALUES ('version', '1.5.6-alpha.1')",
+		"CREATE TABLE tls (id INTEGER PRIMARY KEY AUTOINCREMENT, server BLOB, client BLOB)",
+		"CREATE TABLE inbounds (id INTEGER PRIMARY KEY AUTOINCREMENT, tls_id INTEGER DEFAULT 0, out_json BLOB)",
+		"CREATE TABLE users (id INTEGER PRIMARY KEY AUTOINCREMENT, username TEXT, password TEXT)",
+	} {
+		if err := bad.Exec(stmt).Error; err != nil {
+			t.Fatalf("seed backup fixture (%s): %v", stmt, err)
+		}
+	}
+	if sqlDB, e := bad.DB(); e == nil {
+		sqlDB.Close()
+	}
+
+	f, err := os.Open(badPath)
+	if err != nil {
+		t.Fatalf("open backup fixture: %v", err)
+	}
+	defer f.Close()
+
+	err = ImportDB(f)
+	if err == nil {
+		t.Fatal("expected ImportDB to reject an unmigratable backup")
+	}
+	if !strings.Contains(err.Error(), "Error migrating db") {
+		t.Fatalf("expected the import to fail in the migration, got: %v", err)
+	}
+
+	var count int64
+	if err := GetDB().Model(&model.Setting{}).Count(&count).Error; err != nil {
+		t.Fatalf("connection pool unusable after a failed import: %v", err)
+	}
+
+	var marker string
+	if err := GetDB().Raw("SELECT value FROM settings WHERE key = ?", "test_marker").Scan(&marker).Error; err != nil {
+		t.Fatalf("read marker: %v", err)
+	}
+	if marker != "original" {
+		t.Fatalf("expected the original database back, marker = %q", marker)
+	}
+}

--- a/database/model/model.go
+++ b/database/model/model.go
@@ -35,20 +35,8 @@ type User struct {
 	TwoFa bool `json:"twoFa" gorm:"->;-:migration"`
 }
 
-// LoginAttempt is the rate limiter's record for one identity -- a source IP or
-// a username, told apart by Scope. It lives in the DB rather than in memory
-// because a restart must not hand an attacker a fresh window, and a restart is
-// not rare here: operators do it on upgrade, and checkCoreJob can do it on its
-// own.
-//
-// One row per identity, updated in place, rather than one row per failure: the
-// window this enforces is the fixed one 3x-ui also settled on, and counting
-// rows would mean an unbounded table plus a COUNT on every login attempt.
 type LoginAttempt struct {
-	Id uint `json:"id" gorm:"primaryKey;autoIncrement"`
-	// "ip" or "user". Both are counted, so a spray across many usernames from
-	// one address and a spray from many addresses at one username each trip a
-	// limit on their own.
+	Id    uint   `json:"id" gorm:"primaryKey;autoIncrement"`
 	Scope string `json:"scope" gorm:"uniqueIndex:idx_login_attempt,priority:1"`
 	Key   string `json:"key" gorm:"uniqueIndex:idx_login_attempt,priority:2"`
 	// Failures counted since WindowStart. After a username ban is served,

--- a/service/loginguard.go
+++ b/service/loginguard.go
@@ -19,7 +19,18 @@ import (
 const (
 	loginScopeIP   = "ip"
 	loginScopeUser = "user"
+	// The first half of a two-step login: the password matched and the request
+	// carried no code. Not a failed attempt -- counting it as one spends the
+	// budget a real user needs to type a code with -- but it has already paid
+	// for a bcrypt comparison, so it cannot be free either. See RecordPrompt.
+	loginScopePrompt = "prompt"
 )
+
+// How much larger the prompt budget is than the failure budget. A genuine
+// two-step login spends one prompt and then clears the tally by succeeding, so
+// this only has to stay clear of someone retrying a handful of times; the point
+// is a ceiling, not a tight limit.
+const promptBudgetFactor = 10
 
 // How long a served username ban stays disarmed after the last attack. A
 // username lockout can otherwise be renewed forever by five more distributed
@@ -133,6 +144,18 @@ func loginKeys(ip, username string) []model.LoginAttempt {
 	return keys
 }
 
+// banKeys is every row that can refuse this attempt, or that a success clears.
+// It is loginKeys plus the prompt row, which is deliberately not in loginKeys:
+// a failed login must not spend the prompt budget, nor a prompt the failure
+// budget, but both refuse, and a completed login clears both.
+func banKeys(ip, username string) []model.LoginAttempt {
+	keys := loginKeys(ip, username)
+	if addr := normalizeLoginIP(ip); addr != "" {
+		keys = append(keys, model.LoginAttempt{Scope: loginScopePrompt, Key: addr})
+	}
+	return keys
+}
+
 // normalizeLoginIP reduces a source address to the identity this limiter
 // counts, on the same terms as the per-client IP limit (core's normalizeSrc).
 // Unmap first, so one client arriving as 1.2.3.4 on one path and ::ffff:1.2.3.4
@@ -182,7 +205,7 @@ func (s *LoginGuardService) BanRemaining(ip, username string) time.Duration {
 
 	now := time.Now().Unix()
 	longest := int64(0)
-	for _, key := range loginKeys(ip, username) {
+	for _, key := range banKeys(ip, username) {
 		row, err := s.find(key.Scope, key.Key)
 		if err != nil {
 			logger.Warning("login guard: read attempt:", err)
@@ -209,32 +232,8 @@ func (s *LoginGuardService) RecordFailure(ip, username string) {
 	}
 
 	now := time.Now().Unix()
-	db := database.GetDB()
 	for _, key := range loginKeys(ip, username) {
-		// One transaction per identity so the read-modify-write cannot
-		// interleave with a concurrent attempt on the same row and lose a
-		// count. SQLite has a single writer, so these serialize anyway.
-		err := db.Transaction(func(tx *gorm.DB) error {
-			row := model.LoginAttempt{Scope: key.Scope, Key: key.Key}
-			err := tx.Where("scope = ? AND key = ?", key.Scope, key.Key).First(&row).Error
-			if err != nil && !database.IsNotFound(err) {
-				return err
-			}
-			wasFree := loginBanRemaining(row, now) == 0
-			row = planLoginFailure(row, now, cfg)
-			row.Scope, row.Key = key.Scope, key.Key
-			if err := tx.Save(&row).Error; err != nil {
-				return err
-			}
-			// Log the transition only, not every attempt that lands while the
-			// ban is already in force.
-			if wasFree && row.BannedUntil > now {
-				logger.Warningf("login guard: %s %q banned for %ds after %d failures",
-					key.Scope, key.Key, cfg.ban, cfg.maxFailures)
-			}
-			return nil
-		})
-		if err != nil {
+		if err := s.bump(key.Scope, key.Key, now, cfg); err != nil {
 			logger.Warning("login guard: record failure:", err)
 		}
 	}
@@ -242,12 +241,67 @@ func (s *LoginGuardService) RecordFailure(ip, username string) {
 	s.sweep(now, cfg)
 }
 
+// RecordPrompt counts one two-factor prompt against the source address, on its
+// own scope and a budget promptBudgetFactor times the failure budget. Keyed on
+// the address alone: the username axis exists to stop a spray across accounts,
+// and reaching a prompt means the password for this one was already correct.
+// Without this the prompt is the panel's one unmetered bcrypt comparison, and
+// whoever holds a leaked password can drive it without limit.
+func (s *LoginGuardService) RecordPrompt(ip string) {
+	cfg, err := s.config()
+	if err != nil {
+		logger.Warning("login guard: read settings:", err)
+		return
+	}
+	if !cfg.enabled() {
+		return
+	}
+	cfg.maxFailures *= promptBudgetFactor
+
+	key := normalizeLoginIP(ip)
+	if key == "" {
+		return
+	}
+	now := time.Now().Unix()
+	if err := s.bump(loginScopePrompt, key, now, cfg); err != nil {
+		logger.Warning("login guard: record prompt:", err)
+	}
+	s.sweep(now, cfg)
+}
+
+// bump applies one more countable event to a row. One transaction per identity
+// so the read-modify-write cannot interleave with a concurrent attempt on the
+// same row and lose a count. SQLite has a single writer, so these serialize
+// anyway.
+func (s *LoginGuardService) bump(scope, key string, now int64, cfg loginGuardConfig) error {
+	return database.GetDB().Transaction(func(tx *gorm.DB) error {
+		row := model.LoginAttempt{Scope: scope, Key: key}
+		err := tx.Where("scope = ? AND key = ?", scope, key).First(&row).Error
+		if err != nil && !database.IsNotFound(err) {
+			return err
+		}
+		wasFree := loginBanRemaining(row, now) == 0
+		row = planLoginFailure(row, now, cfg)
+		row.Scope, row.Key = scope, key
+		if err := tx.Save(&row).Error; err != nil {
+			return err
+		}
+		// Log the transition only, not every attempt that lands while the ban
+		// is already in force.
+		if wasFree && row.BannedUntil > now {
+			logger.Warningf("login guard: %s %q banned for %ds after %d attempts",
+				scope, key, cfg.ban, cfg.maxFailures)
+		}
+		return nil
+	})
+}
+
 // RecordSuccess clears partial tallies and rearms a username row whose ban was
 // already served. An active ban is not clearable this way because its request
 // never reaches the password check.
 func (s *LoginGuardService) RecordSuccess(ip, username string) {
 	db := database.GetDB()
-	for _, key := range loginKeys(ip, username) {
+	for _, key := range banKeys(ip, username) {
 		err := db.Where("scope = ? AND key = ?", key.Scope, key.Key).
 			Delete(&model.LoginAttempt{}).Error
 		if err != nil {


### PR DESCRIPTION
Two follow-ups to the login guard added in #112. Both are narrow; neither
changes the panel's behaviour for a default configuration.

## The generated nginx is not always on loopback

`getRemoteIp` trusts loopback as an implicit proxy peer when `webNginx` is set.
That only matches what the generated vhost actually does when `webListen` is
empty or a wildcard: `upstreamAddr` ([service/acme.go](../blob/main/service/acme.go))
dials the configured address otherwise, so nginx reaches the panel *from* its
own bind address and the `X-Forwarded-For` the vhost sets was thrown away.

Every login was then attributed to that address. The Admins page's last-login
column showed it for everybody, and the limiter's per-address budget collapsed
into one budget for the whole panel — five failures from anyone refuse
everyone, and unlike the username scope the address scope rearms after each
ban. Filling in `webTrustedProxies` by hand fixed it, but nothing said so, and
this configuration worked before #112.

The extra peer is now derived from `webListen` the same way `upstreamAddr`
derives the dial address, so the two cannot drift apart. Verified against a
real settings row:

| `webNginx` | `webListen` | peer | recorded |
|---|---|---|---|
| on | *(empty)* | 127.0.0.1 | the forwarded client |
| on | `10.0.0.5` | 10.0.0.5 | the forwarded client — **was** `10.0.0.5` |
| on | `0.0.0.0` | 127.0.0.1 | the forwarded client |
| on | `10.0.0.5` | 198.51.100.9 | 198.51.100.9 — a stranger's forged header still buys nothing |
| off | `10.0.0.5` | 10.0.0.5 | 10.0.0.5 |

## The two-factor prompt was unmetered

The first half of a two-step login — password correct, no code — was counted
as a failure, which spent the budget a real user needs to type a code with, so
#112's review dropped the counting. That left it counted nowhere, and it is
the one place the panel performs a bcrypt comparison without a limit above it:
whoever holds a leaked password but not the second factor can drive it as fast
as they like.

It now has its own scope with a budget ten times the failure budget (50 per
window at the shipped defaults), keyed on the source address alone — the
username axis exists to stop a spray across accounts, and reaching a prompt
means the password for this one was already correct. A genuine two-step login
spends one prompt and then clears the tally by succeeding, so the failure
budget stays untouched and the prompt budget is never approached.

Panels without two-factor authentication never reach this path, and any of the
three limiter settings at zero disables it as before.

## Verification

Backend CI gate is green locally (`go vet`, tagged build, `go test ./...`).
The frontend is untouched.

Two new tests plus one rewritten: the prompt spends no failure budget but is
recorded, the prompt budget is finite and strictly larger than the failure
budget, and `generatedProxyPeer` agrees with `upstreamAddr` on every wildcard
spelling. Beyond that, a real two-step login was driven end to end against a
live database — the prompt row appears after the first leg and every row is
gone after the second.


---

# Also in this PR

The review of the above turned up unrelated work that landed on the same
branch. Three further commits, each standalone.

## `LoginAttempt` scope comments (3470518)

The type and field comments still said a row is counted against `"ip"` or
`"user"` only, which the 2FA prompt scope added above makes wrong. Removed
rather than corrected — `service/loginguard.go` is the description worth
keeping in sync.

## Migrations run at start-up (a9e9a6b)

The in-panel update button swaps the binary and restarts the service without
ever calling `sui migrate`, so **every panel-updated instance was left
unmigrated** — only the install script ran it. `APP.Init` now runs them itself,
before it opens the database, covering every restart path.

That meant `MigrateDb` had to stop calling `log.Fatal`: a data repair that
cannot be applied must not keep the panel from booting. It returns an error,
recovers panics into one, and `sui migrate` exits 1 on failure instead of
succeeding silently. Three latent faults surfaced on the way:

| Fault | Effect |
|---|---|
| `dbVersion[0:3]` | panicked on any version string shorter than 3 chars |
| `Save` on an empty slice | `ErrEmptySlice` — a database with no TLS rows or no clients failed to migrate, and `log.Fatal` took the process with it |
| unconditional stdout | three untimestamped, unlevelled lines per restart, on a channel `SUI_LOG_LEVEL` cannot turn down |

The last one is why there is a `MigrateDbQuietly`. Routing to `logger` is not
an option — only `APP.Init` initialises that handle, so the same call from
`sui migrate` would dereference nil.

## Backup and import no longer destroy the database (1560b97)

`GetDb` built its scratch path as `dir + name` with no separator, writing to
`/usr/local/s-uisui_<stamp>.db`; the stamp's layout `20060102-200203` resolves
to year-month-day-**day-hour**, so it only varied hourly. Both are now one
`os.CreateTemp` in the DB folder.

`ImportDB` closes the pool before it renames files, and the package-level
handle outlives that close, so every failure path left `GetDB()` serving a shut
pool — the panel stayed up answering `sql: database is closed` until someone
restarted it by hand. It now reopens on the way out, but only when the file it
would open is really the operator's own database:

- **Not when nothing is left at the path.** `InitDB` creates the file when it
  is missing and `initUser` seeds `admin/admin` into it, so reopening there
  swapped the operator's data for an empty panel anyone can log into.
- **Not when the upload is still at the path** because the rollback failed —
  the panel would return on the uploaded backup's `users` table, locking the
  operator out in favour of whoever produced it.

The rollback could not succeed on Windows at all: `InitDB` opens the pool
before it can fail in `AutoMigrate`/`initUser`, and the recovery renames over
that very path, which the platform refuses while the process holds it open.
Verified directly — `Access is denied.` with the pool open, `<nil>` after
releasing it.

Finally the fallback copy is no longer deleted unconditionally. Where the
rollback failed it is the operator's last copy, and the error now names its
path; a pre-existing one is archived under a dated name rather than removed,
because retrying the import is the natural reaction to that failure and the old
cleanup ate exactly the file the failure was trying to save.

## Verification

`gofmt`, `go vet ./...`, the tagged build and `go test ./...` are green for the
whole branch. The frontend is untouched throughout.

`database/backup_test.go` is new: it drives a failing import and asserts the
pool is still usable and the original database is back. Beyond it, each claim
above was checked against a live database with throwaway probes — the
`admin/admin` seeding, the Windows rename refusal, the archive surviving a
second import, and concurrent exports leaving no scratch files behind.
