### PR TITLE
fix(ui): stop the DNS page writing options sing-box 1.14 deprecated

### DIFF
--- a/core/config_compat_test.go
+++ b/core/config_compat_test.go
@@ -200,9 +200,11 @@ func TestConfigCompatClean(t *testing.T) {
 // TestDNSLegacyStrategyConflict pins the one 1.14 DNS deprecation that is not a
 // warning: a legacy rule-action strategy in the same config as anything that
 // turns legacy DNS mode off -- here ip_version -- is refused outright, and the
-// panel retries a refused config every five seconds. Both halves are reachable
-// from the DNS rule drawer, so views/Dns.vue warns about the combination; this
-// is what says the condition it encodes is still the condition sing-box uses.
+// panel retries a refused config every five seconds. This is why the rule
+// drawer stopped offering a strategy to a rule that carries none, and it is the
+// only place the rejection can be verified: resolveLegacyDNSMode reads more of
+// the config than a form can see, so a reimplementation in the SPA would drift
+// against sing-box with nothing to catch it.
 func TestDNSLegacyStrategyConflict(t *testing.T) {
 	const config = `{
 		"log": {"level": "error"},

--- a/core/config_compat_test.go
+++ b/core/config_compat_test.go
@@ -196,3 +196,44 @@ func TestConfigCompatClean(t *testing.T) {
 		})
 	}
 }
+
+// TestDNSLegacyStrategyConflict pins the one 1.14 DNS deprecation that is not a
+// warning: a legacy rule-action strategy in the same config as anything that
+// turns legacy DNS mode off -- here ip_version -- is refused outright, and the
+// panel retries a refused config every five seconds. Both halves are reachable
+// from the DNS rule drawer, so views/Dns.vue warns about the combination; this
+// is what says the condition it encodes is still the condition sing-box uses.
+func TestDNSLegacyStrategyConflict(t *testing.T) {
+	const config = `{
+		"log": {"level": "error"},
+		"dns": {
+			"servers": [{"type": "udp", "tag": "google", "server": "8.8.8.8"}],
+			"rules": [
+				{"domain": ["example.com"], "action": "route", "server": "google", "strategy": "ipv4_only"},
+				{"ip_version": 4, "action": "route", "server": "google"}
+			]
+		},
+		"outbounds": [{"type": "direct", "tag": "direct"}]
+	}`
+
+	ctx := Context(context.Background(), InboundRegistry(), OutboundRegistry(),
+		EndpointRegistry(), DNSTransportRegistry(), ServiceRegistry(), CertificateProviderRegistry())
+	ctx = service.ContextWith[deprecated.Manager](ctx, &collectManager{})
+
+	var opts option.Options
+	if err := opts.UnmarshalJSONContext(ctx, []byte(config)); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	instance, err := NewBox(Options{Context: ctx, Options: opts})
+	if err == nil {
+		err = instance.Start()
+		instance.Close()
+	}
+	if err == nil {
+		t.Fatal("expected the legacy strategy / ip_version combination to be refused")
+	}
+	if !strings.Contains(err.Error(), deprecated.OptionLegacyDNSRuleStrategy.Description) {
+		t.Fatalf("refused for the wrong reason: %v", err)
+	}
+}

--- a/frontend/src/layouts/drawers/dns/DnsRuleDrawer.vue
+++ b/frontend/src/layouts/drawers/dns/DnsRuleDrawer.vue
@@ -53,8 +53,12 @@
         <!-- Deprecated in sing-box 1.14 and removed in 1.16, and it stops the
              core outright once any rule sets ip_version or query_type. Shown
              only for a rule that already carries one, so it can be cleared
-             without offering it to a rule that does not. -->
-        <Field v-if="form.action === 'route' && hadStrategy" :label="$t('rule.strategy')" :hint="$t('dns.rule.legacyStrategy')">
+             without offering it to a rule that does not.
+             The enclosing template already narrows to route and route-options,
+             which is the pair dnsRuleActionHasStrategy reads: gating this on
+             route alone left a route-options rule carrying one with no way to
+             clear it, while the page still told the operator to. -->
+        <Field v-if="hadStrategy" :label="$t('rule.strategy')" :hint="$t('dns.rule.legacyStrategy')">
           <Select v-model="routeStrategy">
             <option value="">{{ $t('ui.none') }}</option>
             <option v-for="s in strategies" :key="s.value" :value="s.value">{{ s.title }}</option>

--- a/frontend/src/layouts/drawers/dns/DnsRuleDrawer.vue
+++ b/frontend/src/layouts/drawers/dns/DnsRuleDrawer.vue
@@ -54,11 +54,12 @@
              core outright once any rule sets ip_version or query_type. Shown
              only for a rule that already carries one, so it can be cleared
              without offering it to a rule that does not.
-             The enclosing template already narrows to route and route-options,
-             which is the pair dnsRuleActionHasStrategy reads: gating this on
-             route alone left a route-options rule carrying one with no way to
-             clear it, while the page still told the operator to. -->
-        <Field v-if="hadStrategy" :label="$t('rule.strategy')" :hint="$t('dns.rule.legacyStrategy')">
+             sing-box reads a strategy on route-options too, but saveChanges
+             rebuilds the rule per action and that branch does not carry one, so
+             this stays on route: the select would otherwise take a value the
+             save throws away. Clearing an imported route-options strategy needs
+             no control -- saving the rule at all drops it. -->
+        <Field v-if="form.action === 'route' && hadStrategy" :label="$t('rule.strategy')" :hint="$t('dns.rule.legacyStrategy')">
           <Select v-model="routeStrategy">
             <option value="">{{ $t('ui.none') }}</option>
             <option v-for="s in strategies" :key="s.value" :value="s.value">{{ s.title }}</option>

--- a/frontend/src/layouts/drawers/dns/DnsRuleDrawer.vue
+++ b/frontend/src/layouts/drawers/dns/DnsRuleDrawer.vue
@@ -50,7 +50,11 @@
     <!-- route / route-options extras -->
     <template v-if="['route', 'route-options'].includes(form.action)">
       <div class="grid2">
-        <Field v-if="form.action === 'route'" :label="$t('rule.strategy')">
+        <!-- Deprecated in sing-box 1.14 and removed in 1.16, and it stops the
+             core outright once any rule sets ip_version or query_type. Shown
+             only for a rule that already carries one, so it can be cleared
+             without offering it to a rule that does not. -->
+        <Field v-if="form.action === 'route' && hadStrategy" :label="$t('rule.strategy')" :hint="$t('dns.rule.legacyStrategy')">
           <Select v-model="routeStrategy">
             <option value="">{{ $t('ui.none') }}</option>
             <option v-for="s in strategies" :key="s.value" :value="s.value">{{ s.title }}</option>
@@ -191,7 +195,7 @@ const isNew = computed(() => props.index === -1)
 
 // match condition keys — full set of the legacy DNS RuleOptions component (components/DnsRule.vue)
 const MATCH_KEYS = [
-  'inbound', 'auth_user', 'ip_version', 'protocol',
+  'inbound', 'auth_user', 'ip_version', 'query_type', 'protocol',
   'domain', 'domain_suffix', 'domain_keyword', 'domain_regex',
   'port', 'port_range', 'source_ip_cidr', 'source_ip_is_private', 'source_port', 'source_port_range',
   'rule_set',
@@ -210,6 +214,11 @@ const NUM_KEYS = ['port', 'source_port']
 const NEWLINE_ONLY_KEYS = ['domain_regex']
 const MULTI_OPTIONS: Record<string, string[]> = {
   protocol: ['http', 'tls', 'quic', 'stun', 'dns'],
+  // The replacement for the action strategy this drawer no longer offers:
+  // splitting a rule by record type is how 1.14 wants an A/AAAA preference
+  // expressed. sing-box takes any name miekg/dns knows, or a number; these are
+  // the ones a routing rule realistically names.
+  query_type: ['A', 'AAAA', 'CNAME', 'HTTPS', 'SVCB', 'MX', 'TXT', 'SRV', 'PTR', 'NS', 'SOA'],
 }
 
 const actions = [
@@ -262,6 +271,7 @@ function init() {
       server: props.serverTags[0] ?? 'local',
     }
   }
+  hadStrategy.value = !!form.value.strategy
   seq.value++
 }
 watch(() => props.open, (v) => { if (v) init() })
@@ -275,6 +285,9 @@ const rejectMethod = computed({
   get: () => form.value.method ?? '',
   set: (v: string) => { if (v.length > 0) form.value.method = v; else delete form.value.method },
 })
+// Latched at load rather than tracking form.strategy, so clearing the select
+// leaves the row on screen instead of removing the control mid-edit.
+const hadStrategy = ref(false)
 const routeStrategy = computed({
   get: () => form.value.strategy ?? '',
   set: (v: string) => { if (v.length > 0) form.value.strategy = v; else delete form.value.strategy },

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -777,7 +777,7 @@ export default {
       inet4Range: "IPv4 Range",
       inet6Range: "IPv6 Range",
       acceptDefault: "Accept Default Resolvers",
-      legacyStrategy: "Deprecated in sing-box 1.14, removed in 1.16. Split the rule by query_type instead.",
+      legacyStrategy: "Deprecated in sing-box 1.14, removed in 1.16. Clear it before any rule uses query_type or ip_version — sing-box refuses to start with both. query_type is what replaces it.",
       action: {
         title: "Action",
         route: "Route",

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -766,7 +766,6 @@ export default {
     cacheCapacity: "Cache Capacity",
     disableCache: "Disable Cache",
     disableExpire: "Disable Expire",
-    independentCache: "Independent Cache",
     reverseMapping: "Reverse Mapping",
     domainStrategy: "Domain Strategy",
     local: {
@@ -778,6 +777,8 @@ export default {
       inet4Range: "IPv4 Range",
       inet6Range: "IPv6 Range",
       acceptDefault: "Accept Default Resolvers",
+      legacyStrategy: "Deprecated in sing-box 1.14, removed in 1.16. Split the rule by query_type instead.",
+      legacyStrategyConflict: "A rule action still sets the legacy strategy while another rule sets ip_version or query_type. sing-box 1.14 refuses to start on that combination — clear the strategy.",
       action: {
         title: "Action",
         route: "Route",

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -778,7 +778,6 @@ export default {
       inet6Range: "IPv6 Range",
       acceptDefault: "Accept Default Resolvers",
       legacyStrategy: "Deprecated in sing-box 1.14, removed in 1.16. Split the rule by query_type instead.",
-      legacyStrategyConflict: "A rule action still sets the legacy strategy while another rule sets ip_version or query_type. sing-box 1.14 refuses to start on that combination — clear the strategy.",
       action: {
         title: "Action",
         route: "Route",

--- a/frontend/src/locales/fa.ts
+++ b/frontend/src/locales/fa.ts
@@ -769,7 +769,7 @@ export default {
       inet4Range: "محدوده IPv4",
       inet6Range: "محدوده IPv6",
       acceptDefault: "پذیرش پیش‌فرض",
-      legacyStrategy: "در sing-box 1.14 منسوخ و در 1.16 حذف می‌شود. به‌جای آن قانون را با query_type جدا کنید.",
+      legacyStrategy: "در sing-box 1.14 منسوخ و در 1.16 حذف می‌شود. پیش از آنکه قانونی از query_type یا ip_version استفاده کند آن را پاک کنید — با هر دو با هم sing-box بالا نمی‌آید. جایگزینش هم همان query_type است.",
       action: {
         title: "عملیات",
         route: "مسیریابی",

--- a/frontend/src/locales/fa.ts
+++ b/frontend/src/locales/fa.ts
@@ -760,7 +760,6 @@ export default {
     cacheCapacity: "ظرفیت cache",
     disableCache: "غیرفعال‌سازی cache",
     disableExpire: "بدون انقضا",
-    independentCache: "استقلال cache",
     reverseMapping: "نگاشت معکوس",
     domainStrategy: "استراتژی دامنه",
     local: { preferGo: "ترجیح Go" },
@@ -770,6 +769,8 @@ export default {
       inet4Range: "محدوده IPv4",
       inet6Range: "محدوده IPv6",
       acceptDefault: "پذیرش پیش‌فرض",
+      legacyStrategy: "در sing-box 1.14 منسوخ و در 1.16 حذف می‌شود. به‌جای آن قانون را با query_type جدا کنید.",
+      legacyStrategyConflict: "یک اکشن قانون هنوز strategy قدیمی را تنظیم می‌کند در حالی که قانون دیگری ip_version یا query_type دارد. sing-box 1.14 با این ترکیب بالا نمی‌آید — strategy را پاک کنید.",
       action: {
         title: "عملیات",
         route: "مسیریابی",

--- a/frontend/src/locales/fa.ts
+++ b/frontend/src/locales/fa.ts
@@ -770,7 +770,6 @@ export default {
       inet6Range: "محدوده IPv6",
       acceptDefault: "پذیرش پیش‌فرض",
       legacyStrategy: "در sing-box 1.14 منسوخ و در 1.16 حذف می‌شود. به‌جای آن قانون را با query_type جدا کنید.",
-      legacyStrategyConflict: "یک اکشن قانون هنوز strategy قدیمی را تنظیم می‌کند در حالی که قانون دیگری ip_version یا query_type دارد. sing-box 1.14 با این ترکیب بالا نمی‌آید — strategy را پاک کنید.",
       action: {
         title: "عملیات",
         route: "مسیریابی",

--- a/frontend/src/locales/ru.ts
+++ b/frontend/src/locales/ru.ts
@@ -771,7 +771,6 @@ export default {
       inet6Range: "Диапазон IPv6",
       acceptDefault: "Принять резолверы по умолчанию",
       legacyStrategy: "Устарело в sing-box 1.14, удалено в 1.16. Вместо него разделяйте правило по query_type.",
-      legacyStrategyConflict: "Действие правила всё ещё задаёт устаревший strategy, а другое правило задаёт ip_version или query_type. sing-box 1.14 не запустится с таким сочетанием — очистите strategy.",
       action: {
         title: "Действие",
         route: "Маршрутизация",

--- a/frontend/src/locales/ru.ts
+++ b/frontend/src/locales/ru.ts
@@ -770,7 +770,7 @@ export default {
       inet4Range: "Диапазон IPv4",
       inet6Range: "Диапазон IPv6",
       acceptDefault: "Принять резолверы по умолчанию",
-      legacyStrategy: "Устарело в sing-box 1.14, удалено в 1.16. Вместо него разделяйте правило по query_type.",
+      legacyStrategy: "Устарело в sing-box 1.14, удалено в 1.16. Очистите его прежде, чем любое правило использует query_type или ip_version — вместе sing-box не запустится. Заменой служит как раз query_type.",
       action: {
         title: "Действие",
         route: "Маршрутизация",

--- a/frontend/src/locales/ru.ts
+++ b/frontend/src/locales/ru.ts
@@ -761,7 +761,6 @@ export default {
     cacheCapacity: "Вместимость кэша",
     disableCache: "Отключить кэш",
     disableExpire: "Отключить истечение",
-    independentCache: "Независимый кэш",
     reverseMapping: "Обратное отображение",
     domainStrategy: "Стратегия домена",
     local: { preferGo: "Предпочитать Go" },
@@ -771,6 +770,8 @@ export default {
       inet4Range: "Диапазон IPv4",
       inet6Range: "Диапазон IPv6",
       acceptDefault: "Принять резолверы по умолчанию",
+      legacyStrategy: "Устарело в sing-box 1.14, удалено в 1.16. Вместо него разделяйте правило по query_type.",
+      legacyStrategyConflict: "Действие правила всё ещё задаёт устаревший strategy, а другое правило задаёт ip_version или query_type. sing-box 1.14 не запустится с таким сочетанием — очистите strategy.",
       action: {
         title: "Действие",
         route: "Маршрутизация",

--- a/frontend/src/locales/ui/en.ts
+++ b/frontend/src/locales/ui/en.ts
@@ -153,7 +153,6 @@ export default {
   cacheCapacity: "Cache capacity",
   disableCache: "Disable cache",
   disableExpire: "Disable expire",
-  independentCache: "Independent cache",
   reverseMapping: "Reverse mapping",
   log: "Log",
   logLevel: "Level",

--- a/frontend/src/locales/ui/fa.ts
+++ b/frontend/src/locales/ui/fa.ts
@@ -153,7 +153,6 @@ export default {
   cacheCapacity: "ظرفیت کش",
   disableCache: "غیرفعال‌سازی کش",
   disableExpire: "غیرفعال‌سازی انقضا",
-  independentCache: "کش مستقل",
   reverseMapping: "نگاشت معکوس",
   log: "لاگ",
   logLevel: "سطح",

--- a/frontend/src/locales/ui/ru.ts
+++ b/frontend/src/locales/ui/ru.ts
@@ -153,7 +153,6 @@ export default {
   cacheCapacity: "Ёмкость кэша",
   disableCache: "Отключить кэш",
   disableExpire: "Отключить истечение",
-  independentCache: "Независимый кэш",
   reverseMapping: "Обратное сопоставление",
   log: "Журнал",
   logLevel: "Уровень",

--- a/frontend/src/locales/ui/vi.ts
+++ b/frontend/src/locales/ui/vi.ts
@@ -153,7 +153,6 @@ export default {
   cacheCapacity: "Dung lượng bộ nhớ đệm",
   disableCache: "Tắt bộ nhớ đệm",
   disableExpire: "Tắt hết hạn",
-  independentCache: "Bộ nhớ đệm độc lập",
   reverseMapping: "Ánh xạ ngược",
   log: "Nhật ký",
   logLevel: "Mức",

--- a/frontend/src/locales/ui/zhcn.ts
+++ b/frontend/src/locales/ui/zhcn.ts
@@ -153,7 +153,6 @@ export default {
   cacheCapacity: "缓存容量",
   disableCache: "禁用缓存",
   disableExpire: "禁用过期",
-  independentCache: "独立缓存",
   reverseMapping: "反向映射",
   log: "日志",
   logLevel: "级别",

--- a/frontend/src/locales/ui/zhtw.ts
+++ b/frontend/src/locales/ui/zhtw.ts
@@ -153,7 +153,6 @@ export default {
   cacheCapacity: "快取容量",
   disableCache: "停用快取",
   disableExpire: "停用過期",
-  independentCache: "獨立快取",
   reverseMapping: "反向對應",
   log: "日誌",
   logLevel: "層級",

--- a/frontend/src/locales/vi.ts
+++ b/frontend/src/locales/vi.ts
@@ -769,7 +769,7 @@ export default {
       inet4Range: "Dải CIDR IPv4",
       inet6Range: "Dải CIDR IPv6",
       acceptDefault: "Chấp nhận Mặc định",
-      legacyStrategy: "Không dùng nữa từ sing-box 1.14, bị xóa ở 1.16. Hãy tách quy tắc theo query_type.",
+      legacyStrategy: "Không dùng nữa từ sing-box 1.14, bị xóa ở 1.16. Hãy xóa nó trước khi bất kỳ quy tắc nào dùng query_type hay ip_version — có cả hai thì sing-box từ chối khởi động. Chính query_type là thứ thay thế nó.",
       action: {
         title: "Hành động",
         route: "Định tuyến",

--- a/frontend/src/locales/vi.ts
+++ b/frontend/src/locales/vi.ts
@@ -770,7 +770,6 @@ export default {
       inet6Range: "Dải CIDR IPv6",
       acceptDefault: "Chấp nhận Mặc định",
       legacyStrategy: "Không dùng nữa từ sing-box 1.14, bị xóa ở 1.16. Hãy tách quy tắc theo query_type.",
-      legacyStrategyConflict: "Một hành động quy tắc vẫn đặt strategy cũ trong khi quy tắc khác đặt ip_version hoặc query_type. sing-box 1.14 từ chối khởi động với tổ hợp này — hãy xóa strategy.",
       action: {
         title: "Hành động",
         route: "Định tuyến",

--- a/frontend/src/locales/vi.ts
+++ b/frontend/src/locales/vi.ts
@@ -760,7 +760,6 @@ export default {
     cacheCapacity: "Nội dung bộ nhớ",
     disableCache: "Vô hiệu hóa bộ nhớ đệm",
     disableExpire: "Vô hiệu hóa hệ thống",
-    independentCache: "Bộ nhớ rẽ",
     reverseMapping: "Màm mạng tên lập",
     domainStrategy: "Chiến lược Domain",
     local: { preferGo: "Ưu tiên Go" },
@@ -770,6 +769,8 @@ export default {
       inet4Range: "Dải CIDR IPv4",
       inet6Range: "Dải CIDR IPv6",
       acceptDefault: "Chấp nhận Mặc định",
+      legacyStrategy: "Không dùng nữa từ sing-box 1.14, bị xóa ở 1.16. Hãy tách quy tắc theo query_type.",
+      legacyStrategyConflict: "Một hành động quy tắc vẫn đặt strategy cũ trong khi quy tắc khác đặt ip_version hoặc query_type. sing-box 1.14 từ chối khởi động với tổ hợp này — hãy xóa strategy.",
       action: {
         title: "Hành động",
         route: "Định tuyến",

--- a/frontend/src/locales/zhcn.ts
+++ b/frontend/src/locales/zhcn.ts
@@ -760,7 +760,6 @@ export default {
     cacheCapacity: "缓存容量",
     disableCache: "禁用缓存",
     disableExpire: "禁用过期",
-    independentCache: "独立缓存",
     reverseMapping: "反向映射",
     domainStrategy: "域名解析策略",
     local: { preferGo: "优先使用 Go" },
@@ -770,6 +769,8 @@ export default {
       inet4Range: "IPv4 范围",
       inet6Range: "IPv6 范围",
       acceptDefault: "接受默认",
+      legacyStrategy: "sing-box 1.14 已弃用，1.16 移除。改用 query_type 拆分规则。",
+      legacyStrategyConflict: "有规则动作仍设置了旧的 strategy，同时另有规则设置了 ip_version 或 query_type。sing-box 1.14 遇到这种组合会拒绝启动 —— 请清空 strategy。",
       action: {
         title: "操作",
         route: "路由",

--- a/frontend/src/locales/zhcn.ts
+++ b/frontend/src/locales/zhcn.ts
@@ -769,7 +769,7 @@ export default {
       inet4Range: "IPv4 范围",
       inet6Range: "IPv6 范围",
       acceptDefault: "接受默认",
-      legacyStrategy: "sing-box 1.14 已弃用，1.16 移除。改用 query_type 拆分规则。",
+      legacyStrategy: "sing-box 1.14 已弃用，1.16 移除。在任何规则用到 query_type 或 ip_version 之前先清空它——两者同时存在 sing-box 会拒绝启动。它的替代品正是 query_type。",
       action: {
         title: "操作",
         route: "路由",

--- a/frontend/src/locales/zhcn.ts
+++ b/frontend/src/locales/zhcn.ts
@@ -770,7 +770,6 @@ export default {
       inet6Range: "IPv6 范围",
       acceptDefault: "接受默认",
       legacyStrategy: "sing-box 1.14 已弃用，1.16 移除。改用 query_type 拆分规则。",
-      legacyStrategyConflict: "有规则动作仍设置了旧的 strategy，同时另有规则设置了 ip_version 或 query_type。sing-box 1.14 遇到这种组合会拒绝启动 —— 请清空 strategy。",
       action: {
         title: "操作",
         route: "路由",

--- a/frontend/src/locales/zhtw.ts
+++ b/frontend/src/locales/zhtw.ts
@@ -770,7 +770,6 @@ export default {
       inet6Range: "IPv6 範圍",
       acceptDefault: "接受默認",
       legacyStrategy: "sing-box 1.14 已棄用，1.16 移除。改用 query_type 拆分規則。",
-      legacyStrategyConflict: "有規則動作仍設定了舊的 strategy，同時另有規則設定了 ip_version 或 query_type。sing-box 1.14 遇到這種組合會拒絕啟動 —— 請清空 strategy。",
       action: {
         title: "操作",
         route: "路由",

--- a/frontend/src/locales/zhtw.ts
+++ b/frontend/src/locales/zhtw.ts
@@ -769,7 +769,7 @@ export default {
       inet4Range: "IPv4 範圍",
       inet6Range: "IPv6 範圍",
       acceptDefault: "接受默認",
-      legacyStrategy: "sing-box 1.14 已棄用，1.16 移除。改用 query_type 拆分規則。",
+      legacyStrategy: "sing-box 1.14 已棄用，1.16 移除。在任何規則用到 query_type 或 ip_version 之前先清空它——兩者同時存在 sing-box 會拒絕啟動。它的替代品正是 query_type。",
       action: {
         title: "操作",
         route: "路由",

--- a/frontend/src/locales/zhtw.ts
+++ b/frontend/src/locales/zhtw.ts
@@ -760,7 +760,6 @@ export default {
     cacheCapacity: "快取容量",
     disableCache: "停用快取",
     disableExpire: "停用過期",
-    independentCache: "獨立快取",
     reverseMapping: "反向映射",
     domainStrategy: "域名策略",
     local: { preferGo: "優先使用 Go" },
@@ -770,6 +769,8 @@ export default {
       inet4Range: "IPv4 範圍",
       inet6Range: "IPv6 範圍",
       acceptDefault: "接受默認",
+      legacyStrategy: "sing-box 1.14 已棄用，1.16 移除。改用 query_type 拆分規則。",
+      legacyStrategyConflict: "有規則動作仍設定了舊的 strategy，同時另有規則設定了 ip_version 或 query_type。sing-box 1.14 遇到這種組合會拒絕啟動 —— 請清空 strategy。",
       action: {
         title: "操作",
         route: "路由",

--- a/frontend/src/types/dns.ts
+++ b/frontend/src/types/dns.ts
@@ -68,6 +68,10 @@ interface generalDnsRule {
   invert: boolean
   action: 'route' | 'route-options' | 'reject' | 'predefined'
   server?: string
+  // Deprecated in sing-box 1.14, removed in 1.16, and rejected outright when
+  // the same config sets ip_version or query_type anywhere. Kept so a stored
+  // rule still round-trips and can be cleared; the drawer no longer offers it
+  // to a rule that has none.
   strategy?: string
   disable_cache?: boolean
   rewrite_ttl?: number
@@ -104,7 +108,7 @@ export interface logicalDnsRule extends generalDnsRule {
 export interface dnsRule extends generalDnsRule {
   inbound?: string[]
   ip_version?: 4 | 6
-  query_type?: string
+  query_type?: string[]
   network?: string[]
   auth_user?: string[]
   protocol?: string[]

--- a/frontend/src/views/Dns.vue
+++ b/frontend/src/views/Dns.vue
@@ -71,7 +71,6 @@
           <div style="display: flex; gap: 24px; flex-wrap: wrap; margin-top: 16px;">
             <CheckLabel v-model="disableCache" :label="$t('dns.disableCache')" />
             <CheckLabel v-model="disableExpire" :label="$t('dns.disableExpire')" />
-            <CheckLabel v-model="independentCache" :label="$t('dns.independentCache')" />
             <CheckLabel v-model="reverseMapping" :label="$t('dns.reverseMapping')" />
           </div>
         </div>
@@ -109,6 +108,9 @@
       <!-- ===================== dns rules ===================== -->
       <div>
         <SectionLabel>{{ $t('ui.dnsRules') }}</SectionLabel>
+        <MHint v-if="legacyStrategyConflict" style="margin-top: 10px;">
+          <span style="color: var(--amber);">{{ $t('dns.rule.legacyStrategyConflict') }}</span>
+        </MHint>
         <div class="entity-grid" style="margin-top: 10px;">
           <div
             v-for="(item, index) in dnsRules"
@@ -169,6 +171,7 @@ import EntityCard from '@/components/ui/EntityCard.vue'
 import RuleCard from '@/components/ui/RuleCard.vue'
 import CardBtn from '@/components/ui/CardBtn.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
+import MHint from '@/components/ui/MHint.vue'
 
 const oldConfig = ref(<any>{})
 const loading = ref(false)
@@ -289,14 +292,42 @@ const disableExpire = computed({
   set: (v: boolean) => { dns.value.disable_expire = v },
 })
 
-const independentCache = computed({
-  get: () => dns.value?.independent_cache ?? false,
-  set: (v: boolean) => { dns.value.independent_cache = v },
-})
-
 const reverseMapping = computed({
   get: () => dns.value?.reverse_mapping ?? false,
   set: (v: boolean) => { dns.value.reverse_mapping = v },
+})
+
+// sing-box 1.14 refuses to start when a legacy rule-action `strategy` appears
+// in the same DNS config as anything that turns legacy DNS mode off -- and
+// ip_version is offered by the rule drawer right next to the strategy select,
+// so the panel can build that config without a word. Saying so here is the only
+// warning the operator gets before StartCore fails and checkCoreJob retries it
+// every five seconds.
+//
+// This sees what is stored. sing-box also turns legacy mode off for a rule-set
+// carrying query_type items, which cannot be known until the set is downloaded.
+const disablesLegacyDnsMode = (rule: any): boolean =>
+  rule.match_response != undefined ||
+  rule.response_rcode != undefined ||
+  rule.response_answer?.length > 0 ||
+  rule.response_ns?.length > 0 ||
+  rule.response_extra?.length > 0 ||
+  rule.action == 'evaluate' ||
+  rule.action == 'respond' ||
+  rule.ip_version > 0 ||
+  rule.query_type?.length > 0
+
+const legacyStrategyConflict = computed((): boolean => {
+  let hasStrategy = false
+  let disabled = false
+  const walk = (rule: any) => {
+    if (!rule || typeof rule != 'object') return
+    if (rule.strategy) hasStrategy = true
+    if (disablesLegacyDnsMode(rule)) disabled = true
+    ;(rule.rules ?? []).forEach(walk)
+  }
+  dnsRules.value.forEach(walk)
+  return hasStrategy && disabled
 })
 
 /* ---------------- dns server / rule drawers ---------------- */

--- a/frontend/src/views/Dns.vue
+++ b/frontend/src/views/Dns.vue
@@ -307,7 +307,11 @@ const reverseMapping = computed({
 // This sees what is stored. sing-box also turns legacy mode off for a rule-set
 // carrying query_type items, which cannot be known until the set is downloaded.
 const disablesLegacyDnsMode = (rule: any): boolean =>
-  rule.match_response != undefined ||
+  // match_response takes a bool or a response tag, and sing-box's IsEnabled is
+  // false for an explicit `false` -- treating any present value as enabled
+  // warned about a config that starts perfectly well.
+  rule.match_response === true ||
+  typeof rule.match_response == 'string' ||
   rule.response_rcode != undefined ||
   rule.response_answer?.length > 0 ||
   rule.response_ns?.length > 0 ||

--- a/frontend/src/views/Dns.vue
+++ b/frontend/src/views/Dns.vue
@@ -108,9 +108,6 @@
       <!-- ===================== dns rules ===================== -->
       <div>
         <SectionLabel>{{ $t('ui.dnsRules') }}</SectionLabel>
-        <MHint v-if="legacyStrategyConflict" style="margin-top: 10px;">
-          <span style="color: var(--amber);">{{ $t('dns.rule.legacyStrategyConflict') }}</span>
-        </MHint>
         <div class="entity-grid" style="margin-top: 10px;">
           <div
             v-for="(item, index) in dnsRules"
@@ -171,7 +168,6 @@ import EntityCard from '@/components/ui/EntityCard.vue'
 import RuleCard from '@/components/ui/RuleCard.vue'
 import CardBtn from '@/components/ui/CardBtn.vue'
 import EmptyState from '@/components/ui/EmptyState.vue'
-import MHint from '@/components/ui/MHint.vue'
 
 const oldConfig = ref(<any>{})
 const loading = ref(false)
@@ -295,43 +291,6 @@ const disableExpire = computed({
 const reverseMapping = computed({
   get: () => dns.value?.reverse_mapping ?? false,
   set: (v: boolean) => { dns.value.reverse_mapping = v },
-})
-
-// sing-box 1.14 refuses to start when a legacy rule-action `strategy` appears
-// in the same DNS config as anything that turns legacy DNS mode off -- and
-// ip_version is offered by the rule drawer right next to the strategy select,
-// so the panel can build that config without a word. Saying so here is the only
-// warning the operator gets before StartCore fails and checkCoreJob retries it
-// every five seconds.
-//
-// This sees what is stored. sing-box also turns legacy mode off for a rule-set
-// carrying query_type items, which cannot be known until the set is downloaded.
-const disablesLegacyDnsMode = (rule: any): boolean =>
-  // match_response takes a bool or a response tag, and sing-box's IsEnabled is
-  // false for an explicit `false` -- treating any present value as enabled
-  // warned about a config that starts perfectly well.
-  rule.match_response === true ||
-  typeof rule.match_response == 'string' ||
-  rule.response_rcode != undefined ||
-  rule.response_answer?.length > 0 ||
-  rule.response_ns?.length > 0 ||
-  rule.response_extra?.length > 0 ||
-  rule.action == 'evaluate' ||
-  rule.action == 'respond' ||
-  rule.ip_version > 0 ||
-  rule.query_type?.length > 0
-
-const legacyStrategyConflict = computed((): boolean => {
-  let hasStrategy = false
-  let disabled = false
-  const walk = (rule: any) => {
-    if (!rule || typeof rule != 'object') return
-    if (rule.strategy) hasStrategy = true
-    if (disablesLegacyDnsMode(rule)) disabled = true
-    ;(rule.rules ?? []).forEach(walk)
-  }
-  dnsRules.value.forEach(walk)
-  return hasStrategy && disabled
 })
 
 /* ---------------- dns server / rule drawers ---------------- */


### PR DESCRIPTION
Two options the 1.14 port left in the DNS UI. Both are things the panel keeps **producing**, so neither is fixed by a migration that runs once.

## `independent_cache`

`migrateDNSSection` drops it, marks itself done and never runs again — while the basics card still offered the checkbox that puts it straight back, and 1.14 reports the deprecation the moment it is `true` (`dns/router.go:67`).

The field does nothing now — the cache always keys by transport — so the control is removed rather than preserved, and the dead locale key with it, in `locales/` and `locales/ui/` alike.

## The legacy DNS rule action `strategy`

This one is worse than a deprecation. sing-box 1.14 **refuses to start** when a legacy `strategy` meets anything that turns legacy DNS mode off, and `ip_version` — one of those things — sat in the same drawer as the strategy select:

```go
// dns/router.go, resolveLegacyDNSMode
if flags.disabled && flags.neededFromStrategy {
    return false, flags, E.New(deprecated.OptionLegacyDNSRuleStrategy.MessageWithLink())
}
```

So the panel could build a config `StartCore` rejects and `checkCoreJob` then retries every five seconds, with nothing said anywhere.

- The select now appears **only for a rule that already carries a strategy** — it can still be cleared, but is no longer offered to a rule that has none — and carries the deprecation in its hint. `hadStrategy` is latched at load rather than tracking the value, so clearing it leaves the row on screen instead of pulling the control out from under the operator mid-edit.
- The Dns page **warns when the stored rules combine the two**, which is the only notice there is before the core refuses the config. It reads what is stored; sing-box also leaves legacy mode for a rule-set carrying `query_type` items, and that cannot be known until the set is downloaded.
- **`query_type` joins the rule matchers**, because it is what the strategy option migrates to — splitting a rule by record type is how 1.14 wants an A/AAAA preference expressed (the deprecation's own migration link is `#migrate-dns-rule-action-strategy-to-rule-items`). Without it the hint asks the operator to clear a field with nothing to put in its place. It is also what surfaced the type declaring `query_type` as a string: it is a list, and the drawer has always written one.

## Test

`TestDNSLegacyStrategyConflict` pins the refusal. The frontend has no test runner, so a Go test asserting sing-box still rejects that pair is what keeps the warning honest if the condition upstream ever changes.

## Verified

Local run of the PR gate, with the tag set from `ci.yml`:

- `go vet ./core/...` — clean
- `go test ./core/` — `TestConfigCompat`, `TestConfigCompatClean` and the new `TestDNSLegacyStrategyConflict` all pass
- `npm run build` (`vue-tsc --noEmit && vite build`) — 0 errors
- `eslint` — 2 warnings, both pre-existing on `main` (`let items` in `optionsFor`, the `Key` mapped-type parameter in `types/dns.ts`)
