### PR TITLE
feat(ui): UDP NAT, the new TUN DNS options, Tailscale SSH and SSH algorithms

### DIFF
--- a/frontend/src/components/forms/in/TProxy.vue
+++ b/frontend/src/components/forms/in/TProxy.vue
@@ -2,12 +2,14 @@
   <div>
     <SectionLabel style="margin-bottom: 12px;">TProxy</SectionLabel>
     <Network :data="inbound" :mb="15" />
+    <UdpNat :data="inbound" />
   </div>
 </template>
 
 <script lang="ts" setup>
 import SectionLabel from '@/components/ui/SectionLabel.vue'
 import Network from '../out/Network.vue'
+import UdpNat from '../out/UdpNat.vue'
 
 defineProps<{ inbound: any }>()
 </script>

--- a/frontend/src/components/forms/in/Tun.vue
+++ b/frontend/src/components/forms/in/Tun.vue
@@ -33,6 +33,29 @@
     <Field v-if="autoRoute && data.auto_redirect" :label="$t('types.tun.fallbackRuleIndex')">
       <input class="input mono" type="number" min="0" v-model.number="fallbackRuleIndex" />
     </Field>
+    <!-- hijack, the default, now also sets the platform's interface DNS and
+         installs platform-level hijacking; native leaves both to the system.
+         dns_address is what hijack answers on. -->
+    <div class="grid2">
+      <Field :label="$t('types.tun.dnsMode')">
+        <Select v-model="dnsMode">
+          <option value="">{{ $t('ui.none') }}</option>
+          <option v-for="m in dnsModes" :key="m" :value="m">{{ m }}</option>
+        </Select>
+      </Field>
+      <Field v-if="dnsMode !== 'disabled'" :label="$t('types.tun.dnsAddress') + ' ' + $t('commaSeparated')">
+        <input class="input mono" placeholder="172.18.0.2" v-model="dnsAddress" />
+      </Field>
+    </div>
+    <div class="grid2">
+      <Field :label="$t('types.tun.includeMac') + ' ' + $t('commaSeparated')">
+        <input class="input mono" placeholder="00:11:22:33:44:55" v-model="includeMac" />
+      </Field>
+      <Field :label="$t('types.tun.excludeMac') + ' ' + $t('commaSeparated')">
+        <input class="input mono" placeholder="00:11:22:33:44:55" v-model="excludeMac" />
+      </Field>
+    </div>
+    <UdpNat :data="data" />
   </div>
 </template>
 
@@ -42,8 +65,11 @@ import { computed } from 'vue'
 import Field from '@/components/ui/Field.vue'
 import SectionLabel from '@/components/ui/SectionLabel.vue'
 import SwitchLabel from '@/components/ui/SwitchLabel.vue'
+import UdpNat from '../out/UdpNat.vue'
 
 const props = defineProps<{ data: any }>()
+
+const dnsModes = ['disabled', 'native', 'hijack']
 
 const addrs = computed({
   get: (): string => props.data.address?.join(',') ?? '',
@@ -87,6 +113,29 @@ const excludeMptcp = computed({
   get: (): boolean => props.data.exclude_mptcp ?? false,
   set: (v: boolean) => { props.data.exclude_mptcp = v },
 })
+
+const dnsMode = computed({
+  get: (): string => props.data.dns_mode ?? '',
+  set: (v: string) => {
+    if (v.length > 0) props.data.dns_mode = v
+    else delete props.data.dns_mode
+    // Nothing answers on it when DNS is off, so the address goes with the mode.
+    if (v === 'disabled') delete props.data.dns_address
+  },
+})
+
+const list = (key: string) =>
+  computed({
+    get: (): string => props.data[key]?.join(',') ?? '',
+    set: (v: string) => {
+      const parts = v.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
+      if (parts.length > 0) props.data[key] = parts
+      else delete props.data[key]
+    },
+  })
+const dnsAddress = list('dns_address')
+const includeMac = list('include_mac_address')
+const excludeMac = list('exclude_mac_address')
 
 const fallbackRuleIndex = computed({
   get: (): number => props.data.auto_redirect_iproute2_fallback_rule_index ?? 32768,

--- a/frontend/src/components/forms/out/UdpNat.vue
+++ b/frontend/src/components/forms/out/UdpNat.vue
@@ -1,0 +1,66 @@
+<template>
+  <div>
+    <SwitchLabel v-model="show" :label="$t('udpNat.title')" />
+    <div v-if="show" class="grid2" style="margin-top: 12px;">
+      <Field :label="$t('udpNat.mapping')" :mb="0">
+        <Select v-model="mapping">
+          <option v-for="b in behaviors" :key="b" :value="b">{{ b }}</option>
+        </Select>
+      </Field>
+      <Field :label="$t('udpNat.filtering')" :mb="0">
+        <Select v-model="filtering">
+          <option v-for="b in behaviors" :key="b" :value="b">{{ b }}</option>
+        </Select>
+      </Field>
+      <Field :label="$t('udpNat.max')" :mb="0">
+        <input class="input mono" type="number" min="0" :value="data.udp_nat_max ?? 0" @input="setMax" />
+      </Field>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import Select from '@/components/ui/Select.vue'
+import { computed, ref, watch } from 'vue'
+import Field from '@/components/ui/Field.vue'
+import SwitchLabel from '@/components/ui/SwitchLabel.vue'
+
+// The NAT mapping and filtering behaviours 1.14 made configurable, shared by
+// everything that owns a UDP NAT: tun, redirect, tproxy and the WireGuard
+// endpoint. endpoint_independent is sing-box's default and is what an empty
+// value means, so selecting it writes no key.
+const behaviors = ['endpoint_independent', 'address_dependent', 'address_and_port_dependent']
+
+const KEYS = ['udp_mapping', 'udp_filtering', 'udp_nat_max']
+
+const props = defineProps<{ data: any }>()
+
+// Revealing the group writes nothing, so clearing the last field does not make
+// the section collapse under the operator mid-edit.
+const show = ref(false)
+watch(
+  () => props.data,
+  () => { show.value = KEYS.some((k) => props.data?.[k] != undefined) },
+  { immediate: true },
+)
+watch(show, (v) => { if (!v) KEYS.forEach((k) => delete props.data[k]) })
+
+const behavior = (key: string) =>
+  computed({
+    get: (): string => props.data?.[key] ?? 'endpoint_independent',
+    set: (v: string) => {
+      if (v && v !== 'endpoint_independent') props.data[key] = v
+      else delete props.data[key]
+    },
+  })
+const mapping = behavior('udp_mapping')
+const filtering = behavior('udp_filtering')
+
+// uint32 in sing-box, so a fraction is refused rather than truncated and would
+// take the whole config down over one field.
+const setMax = (event: Event) => {
+  const value = Number((event.target as HTMLInputElement).value)
+  if (Number.isInteger(value) && value > 0) props.data.udp_nat_max = value
+  else delete props.data.udp_nat_max
+}
+</script>

--- a/frontend/src/components/forms/out/protocols/Ssh.vue
+++ b/frontend/src/components/forms/out/protocols/Ssh.vue
@@ -115,9 +115,15 @@ const optionHostKey = computed({
 })
 const CRYPTO_KEYS = ['cipher', 'mac', 'kex_algorithm']
 
+// Switching on seeds the first key, the way optionAlgorithms does: this getter
+// reads the data rather than holding state of its own, so writing nothing would
+// leave it false and the section it gates would never open.
 const optionCrypto = computed({
   get: (): boolean => CRYPTO_KEYS.some((k) => props.data[k] != undefined),
-  set: (v: boolean) => { if (!v) CRYPTO_KEYS.forEach((k) => delete props.data[k]) },
+  set: (v: boolean) => {
+    if (v) props.data.cipher = props.data.cipher ?? []
+    else CRYPTO_KEYS.forEach((k) => delete props.data[k])
+  },
 })
 
 const cryptoList = (key: string) =>

--- a/frontend/src/components/forms/out/protocols/Ssh.vue
+++ b/frontend/src/components/forms/out/protocols/Ssh.vue
@@ -10,6 +10,7 @@
         <div class="pop-item"><SwitchLabel v-model="optionKey" label="SSH Key" /></div>
         <div class="pop-item"><SwitchLabel v-model="optionHostKey" :label="$t('types.ssh.hostKey')" /></div>
         <div class="pop-item"><SwitchLabel v-model="optionAlgorithms" :label="$t('types.ssh.algorithm')" /></div>
+        <div class="pop-item"><SwitchLabel v-model="optionCrypto" :label="$t('types.ssh.crypto')" /></div>
         <div class="pop-item"><SwitchLabel v-model="optionVer" :label="$t('types.ssh.clientVer')" /></div>
       </div>
     </Pop>
@@ -52,6 +53,22 @@
       <input class="input mono" v-model="data.client_version" />
     </Field>
   </div>
+  <!-- Narrowing what the handshake will negotiate. Left unset, the ssh library
+       picks its own defaults; naming any of the three replaces that list
+       outright rather than adding to it. -->
+  <template v-if="optionCrypto">
+    <Field :label="$t('types.ssh.cipher') + ' ' + $t('commaSeparated')">
+      <input class="input mono" placeholder="aes128-gcm@openssh.com" v-model="cipher" />
+    </Field>
+    <div class="grid2">
+      <Field :label="$t('types.ssh.mac') + ' ' + $t('commaSeparated')" :mb="0">
+        <input class="input mono" placeholder="hmac-sha2-256" v-model="mac" />
+      </Field>
+      <Field :label="$t('types.ssh.kex') + ' ' + $t('commaSeparated')" :mb="0">
+        <input class="input mono" placeholder="curve25519-sha256" v-model="kexAlgorithm" />
+      </Field>
+    </div>
+  </template>
 </template>
 
 <script lang="ts" setup>
@@ -96,6 +113,26 @@ const optionHostKey = computed({
   get: (): boolean => props.data.host_key != undefined,
   set: (v: boolean) => { props.data.host_key = v ? '' : undefined },
 })
+const CRYPTO_KEYS = ['cipher', 'mac', 'kex_algorithm']
+
+const optionCrypto = computed({
+  get: (): boolean => CRYPTO_KEYS.some((k) => props.data[k] != undefined),
+  set: (v: boolean) => { if (!v) CRYPTO_KEYS.forEach((k) => delete props.data[k]) },
+})
+
+const cryptoList = (key: string) =>
+  computed({
+    get: (): string => props.data[key]?.join(',') ?? '',
+    set: (v: string) => {
+      const parts = v.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
+      if (parts.length > 0) props.data[key] = parts
+      else delete props.data[key]
+    },
+  })
+const cipher = cryptoList('cipher')
+const mac = cryptoList('mac')
+const kexAlgorithm = cryptoList('kex_algorithm')
+
 const optionAlgorithms = computed({
   get: (): boolean => props.data.host_key_algorithms != undefined,
   set: (v: boolean) => { props.data.host_key_algorithms = v ? [] : undefined },

--- a/frontend/src/components/forms/out/protocols/Tailscale.vue
+++ b/frontend/src/components/forms/out/protocols/Tailscale.vue
@@ -82,13 +82,18 @@
     <Field :label="$t('types.ts.advRoutes') + ' ' + $t('commaSeparated')">
       <input class="input mono" v-model="advertiseRoutes" />
     </Field>
-    <Field :label="$t('types.ts.advTags') + ' ' + $t('commaSeparated')">
-      <input class="input mono" placeholder="tag:server" v-model="advertiseTags" />
-    </Field>
     <div style="margin-bottom: 15px;">
       <SwitchLabel v-model="advertiseExitNode" :label="$t('types.ts.advExitNode')" />
     </div>
   </template>
+
+  <!-- The ACL tags the node claims for itself, which is unrelated to whether it
+       advertises routes: optionAdvRoutes only clears advertise_routes and
+       advertise_exit_node, so a tag left inside that section outlived it with
+       nothing on screen to remove it. -->
+  <Field :label="$t('types.ts.advTags') + ' ' + $t('commaSeparated')">
+    <input class="input mono" placeholder="tag:server" v-model="advertiseTags" />
+  </Field>
 
   <div class="grid2">
     <Field :label="$t('ui.listenPort')">

--- a/frontend/src/components/forms/out/protocols/Tailscale.vue
+++ b/frontend/src/components/forms/out/protocols/Tailscale.vue
@@ -16,6 +16,7 @@
         <div class="pop-item"><SwitchLabel v-model="optionSysIf" :label="$t('types.ts.systemInterface')" /></div>
         <div class="pop-item"><SwitchLabel v-model="optionAdvRoutes" :label="$t('types.ts.advRoutes')" /></div>
         <div class="pop-item"><SwitchLabel v-model="optionUdpTimeout" :label="$t('types.ts.udpTimeout')" /></div>
+        <div class="pop-item"><SwitchLabel v-model="optionSsh" :label="$t('types.ts.sshServer')" /></div>
       </div>
     </Pop>
   </div>
@@ -81,8 +82,33 @@
     <Field :label="$t('types.ts.advRoutes') + ' ' + $t('commaSeparated')">
       <input class="input mono" v-model="advertiseRoutes" />
     </Field>
+    <Field :label="$t('types.ts.advTags') + ' ' + $t('commaSeparated')">
+      <input class="input mono" placeholder="tag:server" v-model="advertiseTags" />
+    </Field>
     <div style="margin-bottom: 15px;">
       <SwitchLabel v-model="advertiseExitNode" :label="$t('types.ts.advExitNode')" />
+    </div>
+  </template>
+
+  <div class="grid2">
+    <Field :label="$t('ui.listenPort')">
+      <input class="input mono" type="number" min="0" max="65535" :value="data.listen_port ?? 0" @input="setListenPort" />
+    </Field>
+    <Field :label="$t('types.ts.taildrop')">
+      <input class="input mono" placeholder="/var/lib/taildrop" v-model="taildropDirectory" />
+    </Field>
+  </div>
+
+  <!-- Serving SSH over the tailnet. The three switches say what it will not
+       offer, so they only mean anything once it is on. -->
+  <template v-if="optionSsh">
+    <div style="margin-bottom: 15px;">
+      <SwitchLabel v-model="sshEnabled" :label="$t('types.ts.sshServer')" />
+    </div>
+    <div v-if="sshEnabled" style="display: flex; gap: 24px; flex-wrap: wrap; margin-bottom: 15px;">
+      <SwitchLabel v-model="sshDisablePty" :label="$t('types.ts.sshDisablePty')" />
+      <SwitchLabel v-model="sshDisableSftp" :label="$t('types.ts.sshDisableSftp')" />
+      <SwitchLabel v-model="sshDisableForwarding" :label="$t('types.ts.sshDisableForwarding')" />
     </div>
   </template>
 </template>
@@ -180,6 +206,52 @@ const optionSysIf = computed({
     }
   },
 })
+const advertiseTags = computed({
+  get: (): string => props.data.advertise_tags?.join(',') ?? '',
+  set: (v: string) => {
+    const parts = v.split(',').map((s) => s.trim()).filter((s) => s.length > 0)
+    if (parts.length > 0) props.data.advertise_tags = parts
+    else delete props.data.advertise_tags
+  },
+})
+
+const taildropDirectory = computed({
+  get: (): string => props.data.taildrop_directory ?? '',
+  set: (v: string) => {
+    const trimmed = (v ?? '').trim()
+    if (trimmed) props.data.taildrop_directory = trimmed
+    else delete props.data.taildrop_directory
+  },
+})
+
+// uint16 in sing-box, and 0 is what "let it pick" is spelled as, so neither a
+// fraction nor a zero leaves a key behind.
+const setListenPort = (event: Event) => {
+  const value = Number((event.target as HTMLInputElement).value)
+  if (Number.isInteger(value) && value > 0 && value <= 65535) props.data.listen_port = value
+  else delete props.data.listen_port
+}
+
+const optionSsh = computed({
+  get: (): boolean => props.data.ssh_server != undefined,
+  set: (v: boolean) => {
+    if (v) props.data.ssh_server = { enabled: true }
+    else delete props.data.ssh_server
+  },
+})
+const sshFlag = (key: string) =>
+  computed({
+    get: (): boolean => props.data.ssh_server?.[key] === true,
+    set: (v: boolean) => {
+      if (v) props.data.ssh_server[key] = true
+      else delete props.data.ssh_server[key]
+    },
+  })
+const sshEnabled = sshFlag('enabled')
+const sshDisablePty = sshFlag('disable_pty')
+const sshDisableSftp = sshFlag('disable_sftp')
+const sshDisableForwarding = sshFlag('disable_forwarding')
+
 const optionUdpTimeout = computed({
   get: () => props.data?.udp_timeout !== undefined,
   set: (v: boolean) => { props.data.udp_timeout = v ? '30s' : undefined },

--- a/frontend/src/components/forms/out/protocols/Wireguard.vue
+++ b/frontend/src/components/forms/out/protocols/Wireguard.vue
@@ -51,6 +51,7 @@
   <Field v-if="data.system" :label="$t('types.wg.ifName')">
     <input class="input mono" v-model="ifName" />
   </Field>
+  <UdpNat :data="data" />
 
   <template v-if="data.peers != undefined">
     <hr class="form-divider" />
@@ -85,6 +86,7 @@ import Ico from '@/components/ui/Ico.vue'
 import Chip from '@/components/ui/Chip.vue'
 import Pop from '@/components/ui/Pop.vue'
 import SwitchLabel from '@/components/ui/SwitchLabel.vue'
+import UdpNat from '../UdpNat.vue'
 import SectionLabel from '@/components/ui/SectionLabel.vue'
 import KeyInput from '@/components/ui/KeyInput.vue'
 import Peer from '../WgPeer.vue'

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -458,6 +458,10 @@ export default {
       hostKey: "Host Keys",
       algorithm: "Key Algorithms",
       clientVer: "Client Version",
+      crypto: "Handshake Algorithms",
+      cipher: "Ciphers",
+      mac: "MACs",
+      kex: "Key Exchange",
       options: "SSH Options",
     },
     tor: {
@@ -475,6 +479,10 @@ export default {
       ifName: "Interface Name",
       excludeMptcp: "Exclude MPTCP",
       fallbackRuleIndex: "iproute2 Fallback Rule Index",
+      dnsMode: "DNS Mode",
+      dnsAddress: "DNS Address",
+      includeMac: "Include MAC Address",
+      excludeMac: "Exclude MAC Address",
     },
     vless: {
       flow: "Flow",
@@ -524,6 +532,12 @@ export default {
       allowLanAccess: "Allow LAN Access",
       advRoutes: "Advertise Routes",
       advExitNode: "Advertise Exit Node",
+      advTags: "Advertise Tags",
+      taildrop: "Taildrop Directory",
+      sshServer: "SSH Server",
+      sshDisablePty: "Disable PTY",
+      sshDisableSftp: "Disable SFTP",
+      sshDisableForwarding: "Disable Forwarding",
       udpTimeout: "UDP Timeout",
     },
     ocm: {
@@ -757,6 +771,12 @@ export default {
       errNoFile: "No file selected.",
       errNoArraysInFile: 'No "rules" or "rule_set" found in the file.',
     },
+  },
+  udpNat: {
+    title: "UDP NAT",
+    mapping: "Mapping Behavior",
+    filtering: "Filtering Behavior",
+    max: "Max Sessions",
   },
   ruleset: {
     add: "Add Ruleset",

--- a/frontend/src/locales/fa.ts
+++ b/frontend/src/locales/fa.ts
@@ -452,6 +452,10 @@ export default {
       hostKey: "کلیدهای هاست‌ها",
       algorithm: "الگوریتم‌ها",
       clientVer: "نسخه کلاینت",
+      crypto: "الگوریتم‌های دست‌دادن",
+      cipher: "رمزها",
+      mac: "MAC‌ها",
+      kex: "تبادل کلید",
       options: "گزینه‌های SSH",
     },
     tor: {
@@ -469,6 +473,10 @@ export default {
       ifName: "نام اینترفیس",
       excludeMptcp: "حذف MPTCP",
       fallbackRuleIndex: "شاخص قوانین fallback در iproute2",
+      dnsMode: "حالت DNS",
+      dnsAddress: "نشانی DNS",
+      includeMac: "شامل نشانی MAC",
+      excludeMac: "استثنای نشانی MAC",
     },
     vless: {
       flow: "جریان",
@@ -518,6 +526,12 @@ export default {
       allowLanAccess: "دسترسی به LAN",
       advRoutes: "تبلیغ مسیرها",
       advExitNode: "تبلیغ درگاه خروج",
+      advTags: "تگ‌های اعلام‌شده",
+      taildrop: "پوشهٔ Taildrop",
+      sshServer: "سرور SSH",
+      sshDisablePty: "غیرفعال‌سازی PTY",
+      sshDisableSftp: "غیرفعال‌سازی SFTP",
+      sshDisableForwarding: "غیرفعال‌سازی فورواردینگ",
       udpTimeout: "مهلت UDP",
     },
     ocm: {
@@ -751,6 +765,12 @@ export default {
       errNoFile: "فایلی انتخاب نشده است.",
       errNoArraysInFile: 'در فایل «rules» یا «rule_set» یافت نشد.',
     },
+  },
+  udpNat: {
+    title: "NAT برای UDP",
+    mapping: "رفتار نگاشت",
+    filtering: "رفتار فیلترینگ",
+    max: "بیشینهٔ نشست‌ها",
   },
   ruleset: {
     add: "ایجاد مجموعه",

--- a/frontend/src/locales/ru.ts
+++ b/frontend/src/locales/ru.ts
@@ -453,6 +453,10 @@ export default {
       hostKey: "Ключи хоста",
       algorithm: "Алгоритмы ключей",
       clientVer: "Версия клиента",
+      crypto: "Алгоритмы рукопожатия",
+      cipher: "Шифры",
+      mac: "MAC",
+      kex: "Обмен ключами",
       options: "Параметры SSH",
     },
     tor: {
@@ -470,6 +474,10 @@ export default {
       ifName: "Имя интерфейса",
       excludeMptcp: "Исключить MPTCP",
       fallbackRuleIndex: "Индекс правила iproute2 fallback",
+      dnsMode: "Режим DNS",
+      dnsAddress: "Адрес DNS",
+      includeMac: "Включить MAC-адреса",
+      excludeMac: "Исключить MAC-адреса",
     },
     vless: {
       flow: "Поток",
@@ -519,6 +527,12 @@ export default {
       allowLanAccess: "Разрешить доступ LAN",
       advRoutes: "Рекламируемые маршруты",
       advExitNode: "Рекламируемый выходной узел",
+      advTags: "Анонсируемые теги",
+      taildrop: "Каталог Taildrop",
+      sshServer: "SSH-сервер",
+      sshDisablePty: "Отключить PTY",
+      sshDisableSftp: "Отключить SFTP",
+      sshDisableForwarding: "Отключить проброс",
       udpTimeout: "Таймаут UDP",
     },
     ocm: {
@@ -752,6 +766,12 @@ export default {
       errNoFile: "Файл не выбран.",
       errNoArraysInFile: 'В файле нет "rules" или "rule_set".',
     },
+  },
+  udpNat: {
+    title: "UDP NAT",
+    mapping: "Поведение отображения",
+    filtering: "Поведение фильтрации",
+    max: "Макс. сессий",
   },
   ruleset: {
     add: "Добавить набор правил",

--- a/frontend/src/locales/vi.ts
+++ b/frontend/src/locales/vi.ts
@@ -452,6 +452,10 @@ export default {
       hostKey: "Khóa Máy chủ",
       algorithm: "Thuật toán Khóa",
       clientVer: "Phiên bản Client",
+      crypto: "Thuật toán bắt tay",
+      cipher: "Cipher",
+      mac: "MAC",
+      kex: "Trao đổi khóa",
       options: "Tùy chọn SSH",
     },
     tor: {
@@ -469,6 +473,10 @@ export default {
       ifName: "Tên Giao diện",
       excludeMptcp: "Loại trừ MPTCP",
       fallbackRuleIndex: "Chỉ số quy tắc dự phòng iproute2",
+      dnsMode: "Chế độ DNS",
+      dnsAddress: "Địa chỉ DNS",
+      includeMac: "Bao gồm địa chỉ MAC",
+      excludeMac: "Loại trừ địa chỉ MAC",
     },
     vless: {
       flow: "Luồng",
@@ -518,6 +526,12 @@ export default {
       allowLanAccess: "Cho phép Truy cập LAN",
       advRoutes: "Quảng bá Đường dẫn",
       advExitNode: "Quảng bá Nút thoát",
+      advTags: "Tag công bố",
+      taildrop: "Thư mục Taildrop",
+      sshServer: "Máy chủ SSH",
+      sshDisablePty: "Tắt PTY",
+      sshDisableSftp: "Tắt SFTP",
+      sshDisableForwarding: "Tắt chuyển tiếp",
       udpTimeout: "Thời gian Chờ UDP",
     },
     ocm: {
@@ -751,6 +765,12 @@ export default {
       errNoFile: "Chưa chọn tệp.",
       errNoArraysInFile: 'Không tìm thấy "rules" hoặc "rule_set" trong tệp.',
     },
+  },
+  udpNat: {
+    title: "UDP NAT",
+    mapping: "Hành vi ánh xạ",
+    filtering: "Hành vi lọc",
+    max: "Số phiên tối đa",
   },
   ruleset: {
     add: "Thêm Bộ quy tắc",

--- a/frontend/src/locales/zhcn.ts
+++ b/frontend/src/locales/zhcn.ts
@@ -452,6 +452,10 @@ export default {
       hostKey: "主机密钥",
       algorithm: "密钥算法",
       clientVer: "客户端版本",
+      crypto: "握手算法",
+      cipher: "加密算法",
+      mac: "MAC 算法",
+      kex: "密钥交换算法",
       options: "SSH 选项",
     },
     tor: {
@@ -469,6 +473,10 @@ export default {
       ifName: "接口名称",
       excludeMptcp: "排除 MPTCP",
       fallbackRuleIndex: "iproute2 回退规则索引",
+      dnsMode: "DNS 模式",
+      dnsAddress: "DNS 地址",
+      includeMac: "包含 MAC 地址",
+      excludeMac: "排除 MAC 地址",
     },
     vless: {
       flow: "流控",
@@ -518,6 +526,12 @@ export default {
       allowLanAccess: "允许 LAN 访问",
       advRoutes: "广告路由",
       advExitNode: "广告出口节点",
+      advTags: "声明标签",
+      taildrop: "Taildrop 目录",
+      sshServer: "SSH 服务端",
+      sshDisablePty: "禁用 PTY",
+      sshDisableSftp: "禁用 SFTP",
+      sshDisableForwarding: "禁用端口转发",
       udpTimeout: "UDP 超时",
     },
     ocm: {
@@ -751,6 +765,12 @@ export default {
       errNoFile: "未选择文件。",
       errNoArraysInFile: '文件中未找到 "rules" 或 "rule_set"。',
     },
+  },
+  udpNat: {
+    title: "UDP NAT",
+    mapping: "映射行为",
+    filtering: "过滤行为",
+    max: "最大会话数",
   },
   ruleset: {
     add: "添加规则集",

--- a/frontend/src/locales/zhtw.ts
+++ b/frontend/src/locales/zhtw.ts
@@ -452,6 +452,10 @@ export default {
       hostKey: "主機密鑰",
       algorithm: "密鑰算法",
       clientVer: "客戶端版本",
+      crypto: "握手演算法",
+      cipher: "加密演算法",
+      mac: "MAC 演算法",
+      kex: "金鑰交換演算法",
       options: "SSH 選項",
     },
     tor: {
@@ -469,6 +473,10 @@ export default {
       ifName: "介面名稱",
       excludeMptcp: "排除 MPTCP",
       fallbackRuleIndex: "iproute2 回退規則索引",
+      dnsMode: "DNS 模式",
+      dnsAddress: "DNS 位址",
+      includeMac: "包含 MAC 位址",
+      excludeMac: "排除 MAC 位址",
     },
     vless: {
       flow: "流量",
@@ -518,6 +526,12 @@ export default {
       allowLanAccess: "允許 LAN 訪問",
       advRoutes: "廣告路由",
       advExitNode: "廣告出口節點",
+      advTags: "宣告標籤",
+      taildrop: "Taildrop 目錄",
+      sshServer: "SSH 伺服端",
+      sshDisablePty: "停用 PTY",
+      sshDisableSftp: "停用 SFTP",
+      sshDisableForwarding: "停用連接埠轉送",
       udpTimeout: "UDP 超時",
     },
     ocm: {
@@ -751,6 +765,12 @@ export default {
       errNoFile: "未選擇檔案。",
       errNoArraysInFile: '檔案中找不到 "rules" 或 "rule_set"。',
     },
+  },
+  udpNat: {
+    title: "UDP NAT",
+    mapping: "對應行為",
+    filtering: "過濾行為",
+    max: "最大工作階段數",
   },
   ruleset: {
     add: "添加規則集",

--- a/frontend/src/types/endpoints.ts
+++ b/frontend/src/types/endpoints.ts
@@ -1,4 +1,5 @@
 import { Dial } from "./dial"
+import { UdpNatFields } from "./inbounds"
 
 export const EpTypes = {
   Wireguard: 'wireguard',
@@ -30,7 +31,7 @@ export interface WgPeer {
   reserved?: number[]
 }
 
-export interface WireGuard extends EndpointBasics, Dial {
+export interface WireGuard extends EndpointBasics, Dial, UdpNatFields {
   system?: boolean
   name?: string
   mtu?: number
@@ -62,6 +63,17 @@ export interface Tailscale extends EndpointBasics, Dial {
   system_interface_name?: string
   system_interface_mtu?: number
   udp_timeout?: string
+  listen_port?: number
+  advertise_tags?: string[]
+  taildrop_directory?: string
+  // Serving SSH over the tailnet, with the three things it can be told not to
+  // offer.
+  ssh_server?: {
+    enabled?: boolean
+    disable_pty?: boolean
+    disable_sftp?: boolean
+    disable_forwarding?: boolean
+  }
 }
 
 // OpenConnect and OpenVPN expose far more options than are modelled here.

--- a/frontend/src/types/inbounds.ts
+++ b/frontend/src/types/inbounds.ts
@@ -38,6 +38,15 @@ export interface Addr {
   remark?: string
 }
 
+// The NAT mapping and filtering behaviours 1.14 made configurable. Carried by
+// everything that owns a UDP NAT -- tun and tproxy here, the WireGuard endpoint
+// in endpoints.ts. Absent means endpoint_independent, sing-box's default.
+export interface UdpNatFields {
+  udp_mapping?: string
+  udp_filtering?: string
+  udp_nat_max?: number
+}
+
 export interface Listen {
   listen: string
   listen_port: number
@@ -156,12 +165,18 @@ export interface Hysteria2 extends InboundBasics, QuicFields {
   }
   brutal_debug?: boolean
 }
-export interface Tun extends InboundBasics {
+export interface Tun extends InboundBasics, UdpNatFields {
   interface_name?: string
   address?: string[]
   mtu?: number
   udp_timeout?: string
   stack?: string
+  // hijack, the default, now also sets the platform's interface DNS and
+  // installs platform-level hijacking; native leaves both alone.
+  dns_mode?: 'disabled' | 'native' | 'hijack'
+  dns_address?: string[]
+  include_mac_address?: string[]
+  exclude_mac_address?: string[]
   auto_route?: boolean
   strict_route?: boolean
   auto_redirect?: boolean
@@ -208,7 +223,9 @@ export interface Cloudflared extends InboundBasics {
   region?: string
 }
 export interface Redirect extends InboundBasics {}
-export interface TProxy extends InboundBasics {
+// Only tproxy carries these: RedirectInboundOptions is ListenOptions and
+// nothing else.
+export interface TProxy extends InboundBasics, UdpNatFields {
   network?: "udp" | "tcp"
 }
 

--- a/frontend/src/types/outbounds.ts
+++ b/frontend/src/types/outbounds.ts
@@ -219,6 +219,9 @@ export interface SSH extends OutboundBasics, Dial  {
   host_key?: string[]
   host_key_algorithms?: string[]
   client_version?: string
+  cipher?: string[]
+  mac?: string[]
+  kex_algorithm?: string[]
 }
 
 export interface Selector extends OutboundBasics {


### PR DESCRIPTION
feat(ui): UDP NAT, the new TUN DNS options, Tailscale SSH and SSH algorithms

The protocol-options tail of 1.14: options that already ride through as raw JSON
but had nowhere to be typed.

UDP NAT. udp_mapping, udp_filtering and udp_nat_max are one shared component,
because they are one group wherever they appear. Absent means
endpoint_independent, sing-box's own default, so choosing it writes no key; the
section reveals without writing anything, the way QuicFields already does.

It appears on tun, tproxy and the WireGuard endpoint. Not on redirect --
RedirectInboundOptions is ListenOptions and nothing else, so the earlier reading
of "redirect/tproxy" was wrong.

TUN gains dns_mode and dns_address. The default, hijack, now also sets the
platform's interface DNS and installs platform-level hijacking, where native
leaves both to the system -- a behaviour change 1.14 made that an operator could
neither see nor opt out of from here. Choosing disabled clears the address with
it, since nothing answers on it then. include_mac_address and
exclude_mac_address come along in the same form.

Tailscale gains listen_port, advertise_tags, taildrop_directory and the SSH
server, whose three switches say what it will not offer and so only appear once
it is on.

SSH gains cipher, mac and kex_algorithm. Naming any of the three replaces the
library's default list rather than adding to it, which the section says.

Left out, with reasons rather than silence:

  - usbip-server and usbip-client. with_usbip ships in every release build, so
    the types are registered and unreachable -- but they are USB-over-IP device
    forwarding, they need a device-match list editor (bus_id, vendor_id,
    product_id, serial) plus a discriminated provider, and nothing else in the
    panel touches that world. It was on the list because the build tag ships,
    which is not the same as anyone wanting it here.
  - netns on listen and dial fields. It references an entry in
    network_namespaces, and that list has no UI at all -- the reference would
    point at something the panel cannot create.
  - The UDP NAT trio on the OpenConnect and OpenVPN endpoints. Their forms model
    a deliberate subset of a much larger option set, and widening that is its
    own decision rather than a field.
