### PR TITLE
feat(ui): the rest of 1.14's neighbour resolution

### DIFF
--- a/frontend/src/layouts/drawers/dns/DnsServerDrawer.vue
+++ b/frontend/src/layouts/drawers/dns/DnsServerDrawer.vue
@@ -39,6 +39,12 @@
     <!-- local -->
     <div v-if="server.type === 'local'" style="margin-bottom: 15px;">
       <SwitchLabel :label="$t('dns.local.preferGo')" :model-value="!!server.prefer_go" @update:model-value="server.prefer_go = $event" />
+      <!-- Single-label hosts answered from neighbour resolution. Setting it is
+           also what turns that resolution on, the way a source_mac_address rule
+           does. -->
+      <Field :label="$t('dns.local.neighborDomain') + ' ' + $t('commaSeparated')" style="margin-top: 12px;">
+        <input class="input mono" v-model="neighborDomain" placeholder="lan" />
+      </Field>
     </div>
 
     <!-- dhcp -->
@@ -167,6 +173,15 @@ const WithoutDial: string[] = [
 ]
 
 const server = ref<any>(createDnsServer('local', { tag: 'dns-' + RandomUtil.randomSeq(3) }))
+
+const neighborDomain = computed({
+  get: (): string => server.value.neighbor_domain?.join(',') ?? '',
+  set: (v: string) => {
+    const parts = v.split(',').map((s: string) => s.trim()).filter((s: string) => s.length > 0)
+    if (parts.length > 0) server.value.neighbor_domain = parts
+    else delete server.value.neighbor_domain
+  },
+})
 
 function init() {
   if (props.index !== -1) {

--- a/frontend/src/layouts/drawers/dns/DnsServerDrawer.vue
+++ b/frontend/src/layouts/drawers/dns/DnsServerDrawer.vue
@@ -175,7 +175,14 @@ const WithoutDial: string[] = [
 const server = ref<any>(createDnsServer('local', { tag: 'dns-' + RandomUtil.randomSeq(3) }))
 
 const neighborDomain = computed({
-  get: (): string => server.value.neighbor_domain?.join(',') ?? '',
+  // Listable in sing-box, so a single domain is legal as a bare string -- and
+  // the config need not have been written by this panel (a restored DB, an
+  // apiv2 config write). Calling join on it throws and takes the drawer down
+  // with it; hostsPath below guards `path` the same way.
+  get: (): string => {
+    const v = server.value.neighbor_domain
+    return Array.isArray(v) ? v.join(',') : v ?? ''
+  },
   set: (v: string) => {
     const parts = v.split(',').map((s: string) => s.trim()).filter((s: string) => s.length > 0)
     if (parts.length > 0) server.value.neighbor_domain = parts

--- a/frontend/src/locales/en.ts
+++ b/frontend/src/locales/en.ts
@@ -826,6 +826,7 @@ export default {
     domainStrategy: "Domain Strategy",
     local: {
       preferGo: "Prefer Go",
+      neighborDomain: "Neighbour domain",
     },
     rule: {
       add: "Add Dns Rule",
@@ -880,6 +881,8 @@ export default {
       defaultRm: "Default Routing Mark",
       defaultDns: "Default DNS Resolver",
       autoBind: "Auto Bind NIC",
+      findNeighbor: "Find neighbours",
+      dhcpLeaseFiles: "DHCP lease files",
     },
     exp: {
       storeFakeIp: "Store Fake IP",

--- a/frontend/src/locales/fa.ts
+++ b/frontend/src/locales/fa.ts
@@ -818,7 +818,7 @@ export default {
     optimisticTimeout: "مهلت خوش‌بینانه",
     acceptSearchDomain: "پذیرش دامنهٔ جستجو",
     domainStrategy: "استراتژی دامنه",
-    local: { preferGo: "ترجیح Go" },
+    local: { preferGo: "ترجیح Go", neighborDomain: "دامنهٔ همسایه" },
     rule: {
       add: "ایجاد قانون DNS",
       title: "قوانین DNS",
@@ -872,6 +872,8 @@ export default {
       defaultRm: "Routing Mark پیش‌فرض",
       defaultDns: "DNS پیش‌فرض",
       autoBind: "انتخاب اتوماتیک کارت شبکه",
+      findNeighbor: "یافتن همسایه‌ها",
+      dhcpLeaseFiles: "فایل‌های اجارهٔ DHCP",
     },
     exp: {
       storeFakeIp: "ذخیره آدرس‌های نامعتبر",

--- a/frontend/src/locales/ru.ts
+++ b/frontend/src/locales/ru.ts
@@ -819,7 +819,7 @@ export default {
     optimisticTimeout: "Оптимистичный таймаут",
     acceptSearchDomain: "Принять search domain",
     domainStrategy: "Стратегия домена",
-    local: { preferGo: "Предпочитать Go" },
+    local: { preferGo: "Предпочитать Go", neighborDomain: "Домен соседей" },
     rule: {
       add: "Добавить правило DNS",
       title: "Правила DNS",
@@ -873,6 +873,8 @@ export default {
       defaultRm: "Маршрут по умолчанию",
       defaultDns: "DNS по умолчанию",
       autoBind: "Автопривязка сетевого интерфейса",
+      findNeighbor: "Искать соседей",
+      dhcpLeaseFiles: "Файлы аренды DHCP",
     },
     exp: {
       storeFakeIp: "Хранить поддельный IP",

--- a/frontend/src/locales/vi.ts
+++ b/frontend/src/locales/vi.ts
@@ -818,7 +818,7 @@ export default {
     optimisticTimeout: "Thời gian chờ lạc quan",
     acceptSearchDomain: "Chấp nhận search domain",
     domainStrategy: "Chiến lược Domain",
-    local: { preferGo: "Ưu tiên Go" },
+    local: { preferGo: "Ưu tiên Go", neighborDomain: "Miền lân cận" },
     rule: {
       add: "Thêm Quy tắc DNS",
       title: "Quy tắc DNS",
@@ -872,6 +872,8 @@ export default {
       defaultRm: "Đánh dấu Định tuyến Mặc định",
       defaultDns: "Máy chủ DNS Mặc định",
       autoBind: "Tự động Ràng buộc NIC",
+      findNeighbor: "Tìm thiết bị lân cận",
+      dhcpLeaseFiles: "Tệp lease DHCP",
     },
     exp: {
       storeFakeIp: "Lưu IP Giả mạo",

--- a/frontend/src/locales/zhcn.ts
+++ b/frontend/src/locales/zhcn.ts
@@ -818,7 +818,7 @@ export default {
     optimisticTimeout: "乐观缓存超时",
     acceptSearchDomain: "接受搜索域",
     domainStrategy: "域名解析策略",
-    local: { preferGo: "优先使用 Go" },
+    local: { preferGo: "优先使用 Go", neighborDomain: "邻居域名" },
     rule: {
       add: "添加 DNS 规则",
       title: "DNS 规则",
@@ -872,6 +872,8 @@ export default {
       defaultRm: "默认路由标记",
       defaultDns: "默认 DNS 解析器",
       autoBind: "自动绑定网卡",
+      findNeighbor: "发现邻居设备",
+      dhcpLeaseFiles: "DHCP 租约文件",
     },
     exp: {
       storeFakeIp: "持久化 Fake-IP",

--- a/frontend/src/locales/zhtw.ts
+++ b/frontend/src/locales/zhtw.ts
@@ -818,7 +818,7 @@ export default {
     optimisticTimeout: "樂觀快取逾時",
     acceptSearchDomain: "接受搜尋網域",
     domainStrategy: "域名策略",
-    local: { preferGo: "優先使用 Go" },
+    local: { preferGo: "優先使用 Go", neighborDomain: "鄰居網域" },
     rule: {
       add: "添加 DNS 規則",
       title: "DNS 規則",
@@ -872,6 +872,8 @@ export default {
       defaultRm: "默認路由標記",
       defaultDns: "默認 DNS 解析器",
       autoBind: "自動綁定網卡",
+      findNeighbor: "探索鄰居裝置",
+      dhcpLeaseFiles: "DHCP 租約檔案",
     },
     exp: {
       storeFakeIp: "存儲假 IP",

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -24,6 +24,13 @@ interface Route {
   final?: string,
   auto_detect_interface?: boolean
   default_interface?: string
+  // Neighbour resolution, which source_mac_address and source_hostname turn on
+  // by themselves. find_neighbor forces it on with no such rule -- it is only
+  // worth setting to get the names into the log. dhcp_lease_files points at
+  // lease files outside the paths sing-box already probes (dnsmasq, odhcpd,
+  // ISC dhcpd, Kea), which is what source_hostname reads on Linux.
+  find_neighbor?: boolean
+  dhcp_lease_files?: string[]
   default_mark?: number
   default_domain_resolver: string
   // Tag of a shared client in http_clients, used by remote rule-sets that

--- a/frontend/src/views/Rules.vue
+++ b/frontend/src/views/Rules.vue
@@ -87,8 +87,12 @@
             <Field :label="$t('basic.routing.defaultRm')" :mb="0">
               <input class="input mono" type="number" min="0" v-model.number="routeMark" />
             </Field>
-            <div style="display: flex; align-items: flex-end; padding-bottom: 6px;">
+            <Field :label="$t('basic.routing.dhcpLeaseFiles') + ' ' + $t('commaSeparated')" :mb="0">
+              <input class="input mono" v-model="dhcpLeaseFiles" placeholder="/var/lib/misc/dnsmasq.leases" />
+            </Field>
+            <div style="display: flex; align-items: flex-end; padding-bottom: 6px; gap: 24px; flex-wrap: wrap;">
               <SwitchLabel v-model="autoDetect" :label="$t('basic.routing.autoBind')" />
+              <SwitchLabel v-model="findNeighbor" :label="$t('basic.routing.findNeighbor')" />
             </div>
           </div>
         </div>
@@ -257,6 +261,28 @@ const routeFinal = computed({
   set: (v: string) => {
     if (v.length > 0) route.value.final = v
     else delete route.value.final
+  },
+})
+
+// Neither is needed to make source_mac_address or source_hostname work --
+// sing-box turns neighbour resolution on for those by itself. find_neighbor is
+// for having the names in the log without such a rule, and dhcp_lease_files is
+// for a DHCP server whose leases are not where sing-box looks, which is the one
+// way hostname matching silently matches nothing on Linux.
+const findNeighbor = computed({
+  get: (): boolean => route.value.find_neighbor === true,
+  set: (v: boolean) => {
+    if (v) route.value.find_neighbor = true
+    else delete route.value.find_neighbor
+  },
+})
+
+const dhcpLeaseFiles = computed({
+  get: (): string => route.value.dhcp_lease_files?.join(',') ?? '',
+  set: (v: string) => {
+    const parts = v.split(',').map((s: string) => s.trim()).filter((s: string) => s.length > 0)
+    if (parts.length > 0) route.value.dhcp_lease_files = parts
+    else delete route.value.dhcp_lease_files
   },
 })
 

--- a/frontend/src/views/Rules.vue
+++ b/frontend/src/views/Rules.vue
@@ -278,7 +278,13 @@ const findNeighbor = computed({
 })
 
 const dhcpLeaseFiles = computed({
-  get: (): string => route.value.dhcp_lease_files?.join(',') ?? '',
+  // Listable in sing-box, so a single path is legal as a bare string -- and the
+  // config need not have been written by this panel. Calling join on it throws
+  // during render, which blanks the whole page rather than one field.
+  get: (): string => {
+    const v = route.value.dhcp_lease_files
+    return Array.isArray(v) ? v.join(',') : v ?? ''
+  },
   set: (v: string) => {
     const parts = v.split(',').map((s: string) => s.trim()).filter((s: string) => s.length > 0)
     if (parts.length > 0) route.value.dhcp_lease_files = parts


### PR DESCRIPTION
feat(ui): the rest of 1.14's neighbour resolution

#149 added source_mac_address and source_hostname without the two route options
and the one DNS server option that surround them.

dhcp_lease_files is the one that matters. Hostname matching reads DHCP leases on
Linux, and sing-box only probes the paths dnsmasq, odhcpd, ISC dhcpd and Kea use
by default -- anywhere else, a source_hostname rule matches nothing at all and
says nothing about why. There was no field to point it at the file.

find_neighbor forces neighbour resolution on where no rule needs it, which the
documentation describes as being for the log. It is not a prerequisite for the
rule items: route.go builds needFindNeighbor from
`hasRule(options.Rules, isNeighborRule) || ... || options.FindNeighbor`, and
isNeighborRule is exactly `len(SourceMACAddress) > 0 || len(SourceHostname) > 0`
-- so writing such a rule already switches it on. #149 was not shipping a
half-connected feature; this only adds the manual override.

neighbor_domain answers single-label hosts from the same resolution, on the
local DNS server beside prefer_go. Setting it also turns the resolution on, the
way a rule item does.

Two more the changelog names under the same heading, domain_label_count and
search_domain_available, are deliberately absent: they exist in 1.14.0's
changelog text and nowhere in its code or configuration docs, so there is
nothing here to write yet.
