### PR TITLE
fix(panel): show each inbound's own traffic, not its clients' totals

### DIFF
--- a/api/apiService.go
+++ b/api/apiService.go
@@ -583,6 +583,12 @@ func (a *ApiService) ImportDb(c *gin.Context) {
 	}
 	defer file.Close()
 	err = database.ImportDB(file)
+	if err == nil {
+		// The imported file carries its own stats history, and the panel keeps
+		// running on the swapped database — so the cached totals belong to a
+		// database that is gone.
+		service.InvalidateInboundTraffic()
+	}
 	jsonMsg(c, "", err)
 }
 

--- a/frontend/src/store/modules/data.ts
+++ b/frontend/src/store/modules/data.ts
@@ -33,6 +33,10 @@ const Data = defineStore('Data', {
     // client name -> currently admitted source IP count. Only clients with a
     // limit and at least one live IP appear; readers fall back to 0.
     ipCounts: <Record<string, number>>{},
+    // inbound tag -> total traffic through it, both directions summed. Measured
+    // per inbound by the core, so it is NOT the sum of its clients' totals: a
+    // client on several inbounds carries one figure across all of them.
+    inboundTraffic: <Record<string, number>>{},
   }),
   getters: {
     // Detour and route targets, inbound side: every inbound plus the endpoints
@@ -71,6 +75,7 @@ const Data = defineStore('Data', {
       if (obj.onlines) this.onlines = obj.onlines
       if (Object.hasOwn(obj, 'nodesStatus')) this.nodesStatus = obj.nodesStatus ?? {}
       if (Object.hasOwn(obj, 'ipCounts')) this.ipCounts = obj.ipCounts ?? {}
+      if (Object.hasOwn(obj, 'inboundTraffic')) this.inboundTraffic = obj.inboundTraffic ?? {}
       // Client traffic is rewritten every stats flush without marking a config
       // change, so the client list rides the live payload too -- waiting for the
       // next full payload would freeze the traffic columns on a panel where

--- a/frontend/src/views/Inbounds.vue
+++ b/frontend/src/views/Inbounds.vue
@@ -151,13 +151,13 @@ const listenOf = (item: any): string =>
   item.listen_port ? `${item.listen ?? ''}:${item.listen_port}` : '—'
 const usersTitle = (item: any): string | undefined =>
   item.users && item.users.length > 0 ? item.users.join('\n') : undefined
-const trafficOf = (item: any): string => {
-  if (!item.users) return '—'
-  const total = (dataStore.clients ?? [])
-    .filter((c: any) => item.users.includes(c.name))
-    .reduce((sum: number, c: any) => sum + (c.up ?? 0) + (c.down ?? 0), 0)
-  return HumanReadable.sizeFormat(total)
-}
+// The core counts each inbound separately, and that is the figure to show.
+// Summing the inbound's clients instead gave every inbound that shares a client
+// the same number, because a client's up/down is its total across all of the
+// inbounds it belongs to. A node replica is measured on its node, which reports
+// per client only, so there is nothing to show for one here.
+const trafficOf = (item: any): string =>
+  item.node_id ? '—' : HumanReadable.sizeFormat(dataStore.inboundTraffic[item.tag] ?? 0)
 
 // ---------------- drawer ----------------
 const drawer = ref({ visible: false, id: 0 })

--- a/service/paneldata.go
+++ b/service/paneldata.go
@@ -89,6 +89,10 @@ func (s *PanelDataService) onlinesHalf() (map[string]interface{}, error) {
 	// so omitting it once nobody is over their limit would leave the last
 	// non-empty counts on screen forever.
 	data["ipCounts"] = GetIPCounts()
+	// Rides the live payload for the same reason client up/down does: it moves
+	// with traffic, not with config, so carrying it on the config half would
+	// freeze it until the next save.
+	data["inboundTraffic"] = s.StatsService.GetInboundTraffic()
 	return data, nil
 }
 

--- a/service/setting.go
+++ b/service/setting.go
@@ -767,6 +767,9 @@ func (s *SettingService) Save(tx *gorm.DB, data json.RawMessage) error {
 			if err != nil {
 				return err
 			}
+			// The per-inbound totals are seeded from those rows; drop them so
+			// they are rebuilt from whatever this transaction leaves behind.
+			InvalidateInboundTraffic()
 		}
 		err = tx.Model(model.Setting{}).Where("key = ?", key).Update("value", obj).Error
 		if err != nil {

--- a/service/stats.go
+++ b/service/stats.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/shenaba/2s-ui/database"
 	"github.com/shenaba/2s-ui/database/model"
+	"github.com/shenaba/2s-ui/logger"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -34,7 +35,88 @@ func setOnlines(o onlines) {
 	onlineMu.Unlock()
 }
 
+// Per-inbound traffic totals, published on the live payload and written by the
+// flush below, so they race the same way onlineResources does and take the same
+// kind of guard. A plain Mutex, not an RWMutex: a read can seed, so there is no
+// read-only path to optimise for.
+//
+// Held in memory rather than aggregated per read. The stats table is the only
+// record of how much went through one inbound, and it grows to a row per active
+// (tag, bucket, direction) across the whole retention window — so answering
+// "total per inbound" from it means re-scanning tens of thousands of rows every
+// ten seconds for a figure that moves by a few kilobytes. Seeded once from that
+// table instead, then advanced by each flush's own deltas, which the flush
+// already has in hand.
+var (
+	inboundTrafficMu     sync.Mutex
+	inboundTraffic       = map[string]int64{}
+	inboundTrafficSeeded bool
+)
+
+// addInboundTraffic folds one flush's per-inbound deltas into the published
+// totals, seeding from the stats table on first use.
+//
+// The caller must run this BEFORE writing the flush's own rows, so the seed and
+// the deltas never cover the same bytes. A failed seed therefore drops this
+// flush rather than counting it twice: the rows still land in the table, and
+// the next attempt reads them back.
+func addInboundTraffic(delta map[string]int64) {
+	inboundTrafficMu.Lock()
+	defer inboundTrafficMu.Unlock()
+	if !seedInboundTrafficLocked() {
+		return
+	}
+	for tag, traffic := range delta {
+		inboundTraffic[tag] += traffic
+	}
+}
+
+func seedInboundTrafficLocked() bool {
+	if inboundTrafficSeeded {
+		return true
+	}
+	var rows []TagTotal
+	err := database.GetDB().Raw(
+		`SELECT tag, SUM(traffic) AS traffic FROM stats WHERE resource = 'inbound' GROUP BY tag`,
+	).Scan(&rows).Error
+	if err != nil {
+		logger.Warning("stats: reading inbound traffic totals failed: ", err)
+		return false
+	}
+	for _, row := range rows {
+		inboundTraffic[row.Tag] = row.Traffic
+	}
+	inboundTrafficSeeded = true
+	return true
+}
+
+// InvalidateInboundTraffic drops the totals so the next read rebuilds them from
+// the stats table. Call it wherever that table is replaced wholesale — clearing
+// it when traffic graphs are turned off, or importing a database over a running
+// panel. Dropping rather than zeroing is what makes it safe inside a
+// transaction that may still roll back: the rebuild reads whatever survived.
+func InvalidateInboundTraffic() {
+	inboundTrafficMu.Lock()
+	inboundTraffic = map[string]int64{}
+	inboundTrafficSeeded = false
+	inboundTrafficMu.Unlock()
+}
+
 type StatsService struct {
+}
+
+// GetInboundTraffic reports each inbound tag's total traffic, both directions
+// summed. Seeds on first call so a panel that has not flushed yet — or one
+// whose core is down — still answers with the history on disk.
+func (s *StatsService) GetInboundTraffic() map[string]int64 {
+	inboundTrafficMu.Lock()
+	defer inboundTrafficMu.Unlock()
+	seedInboundTrafficLocked()
+	totals := make(map[string]int64, len(inboundTraffic))
+	for tag, traffic := range inboundTraffic {
+		totals[tag] = traffic
+	}
+	return totals
 }
 
 func (s *StatsService) SaveStats(enableTraffic bool, bucketSeconds int64) error {
@@ -78,6 +160,7 @@ func (s *StatsService) SaveStats(enableTraffic bool, bucketSeconds int64) error 
 	// up+down collapse into a single UPDATE.
 	type traffic struct{ up, down int64 }
 	userTraffic := map[string]*traffic{}
+	inboundDelta := map[string]int64{}
 	seenInbound := map[string]bool{}
 	seenOutbound := map[string]bool{}
 	for _, stat := range *stats {
@@ -87,6 +170,7 @@ func (s *StatsService) SaveStats(enableTraffic bool, bucketSeconds int64) error 
 				seenInbound[stat.Tag] = true
 				fresh.Inbound = append(fresh.Inbound, stat.Tag)
 			}
+			inboundDelta[stat.Tag] += stat.Traffic
 		case "outbound":
 			if !seenOutbound[stat.Tag] {
 				seenOutbound[stat.Tag] = true
@@ -110,6 +194,10 @@ func (s *StatsService) SaveStats(enableTraffic bool, bucketSeconds int64) error 
 	// Publish before the DB work below: the online lists are complete now, and
 	// a failed traffic write must not leave readers on a stale set.
 	setOnlines(fresh)
+
+	// Before the upsert below, which is what makes the seed and these deltas
+	// disjoint — see addInboundTraffic.
+	addInboundTraffic(inboundDelta)
 
 	for name, t := range userTraffic {
 		update := map[string]interface{}{"online_at": now}

--- a/service/stats_test.go
+++ b/service/stats_test.go
@@ -68,3 +68,74 @@ func TestTopTags(t *testing.T) {
 		t.Errorf("client ranking is %+v, want just alice", users)
 	}
 }
+
+// The inbounds list shows one traffic figure per inbound. It cannot be the sum
+// of that inbound's clients: a client's up/down is its total across every
+// inbound it belongs to, so two inbounds sharing one busy client reported the
+// same number. This is the figure the core actually measured per inbound —
+// seeded from the stats table, then advanced by each flush.
+func TestInboundTrafficSeedsThenAccumulates(t *testing.T) {
+	logger.InitLogger(logging.CRITICAL)
+
+	dir := t.TempDir()
+	if err := database.InitDB(filepath.Join(dir, "inboundtraffic.db")); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.CloseDBForTest(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
+	db := database.GetDB()
+
+	now := time.Now().Unix()
+	rows := []model.Stats{
+		{Resource: "inbound", Tag: "busy", DateTime: now - 60, Direction: true, Traffic: 300},
+		{Resource: "inbound", Tag: "busy", DateTime: now - 60, Direction: false, Traffic: 200},
+		// An older bucket still counts: this is a total, not a window.
+		{Resource: "inbound", Tag: "busy", DateTime: now - 90000, Direction: true, Traffic: 1},
+		{Resource: "inbound", Tag: "quiet", DateTime: now - 60, Direction: true, Traffic: 10},
+		// The same client's traffic under another resource must not be folded in.
+		{Resource: "user", Tag: "alice", DateTime: now - 60, Direction: true, Traffic: 500},
+		{Resource: "outbound", Tag: "direct", DateTime: now - 60, Direction: true, Traffic: 700},
+	}
+	for _, row := range rows {
+		if err := db.Create(&row).Error; err != nil {
+			t.Fatalf("seed %s/%s: %v", row.Resource, row.Tag, err)
+		}
+	}
+
+	// Package state outlives one test.
+	InvalidateInboundTraffic()
+	t.Cleanup(InvalidateInboundTraffic)
+
+	var stats StatsService
+	got := stats.GetInboundTraffic()
+	want := map[string]int64{"busy": 501, "quiet": 10}
+	if len(got) != len(want) {
+		t.Fatalf("seeded totals %v, want %v", got, want)
+	}
+	for tag, traffic := range want {
+		if got[tag] != traffic {
+			t.Errorf("seeded %q = %d, want %d", tag, got[tag], traffic)
+		}
+	}
+
+	// A flush advances the totals without re-reading the table, and an inbound
+	// with no history at all starts from its delta.
+	addInboundTraffic(map[string]int64{"busy": 7, "brandnew": 3})
+	got = stats.GetInboundTraffic()
+	if got["busy"] != 508 {
+		t.Errorf("busy after flush = %d, want 508", got["busy"])
+	}
+	if got["brandnew"] != 3 {
+		t.Errorf("brandnew after flush = %d, want 3", got["brandnew"])
+	}
+
+	// The returned map is a copy: a caller mutating it must not corrupt the
+	// published totals.
+	got["busy"] = 0
+	if again := stats.GetInboundTraffic(); again["busy"] != 508 {
+		t.Errorf("busy = %d after a caller mutated an earlier result, want 508", again["busy"])
+	}
+}


### PR DESCRIPTION
The traffic column on the inbounds list summed the `up`/`down` of every client on
that inbound. A client's `up`/`down` is its total across **every** inbound it
belongs to, so under the multi-inbound model the column showed roughly the same
number on every card.

On a test panel where one busy client sat on all six inbounds, every card read
`5.11 GB` — while the core had actually measured this:

| inbound | before | after |
|---|---|---|
| tuic-41793 | 5.11 GB | **6.30 GB** |
| hysteria-32015 | 5.11 GB | **468.42 MB** |
| tuic-27203 | 5.11 GB | **16.67 KB** |
| vless-18765 | 5.11 GB | **20.96 MB** |
| vless-27350 | 5.11 GB | **44.81 KB** |
| hysteria2-32015 (node replica) | 5.11 GB | **—** |

## What changed

The per-inbound figure only exists in the `stats` table under
`resource='inbound'`, and aggregating it per read is not affordable: one row per
active (tag, bucket, direction) over the whole retention window, re-scanned by
`api/load` and by the 10s push for a number that moves by a few kilobytes.

So `StatsService` keeps the totals in memory — seeded once from that table, then
advanced by each flush's own per-inbound deltas, which `SaveStats` already has in
hand. The seed runs before the flush writes its rows, so the two never cover the
same bytes; a failed seed drops that flush instead of double-counting it, and the
next attempt reads the rows back out of the table.

It rides the **live** payload next to `onlines`/`ipCounts`, not the config half:
it moves with traffic rather than with config, and the config half is only
rebuilt when a write marks a change — an idle panel would freeze the column until
someone saved something.

Anything that replaces the stats table wholesale calls
`InvalidateInboundTraffic`: setting `trafficAge` to 0 (which deletes every row)
and `ImportDB` (which swaps the database under a running panel). It drops the
totals rather than zeroing them, so the rebuild reads whatever survived — which
is what makes the call safe inside a transaction that may still roll back.

Two behaviour notes:

- A **node replica** shows `—` rather than `0`. Its traffic is measured on its
  node, which reports per client only, so the master has no per-inbound figure
  for it.
- Inbounds with no user list at all (shadowtls below v3, managed shadowsocks)
  used to show `—` and now show their real traffic.

## Verification

- Full PR gate locally: `check-protocol-copies.sh` (8/8 ok), `go vet`, `go build`
  and `go test ./...` with the CI tag set and `-checklinkname=0`; plus
  `go test -race ./service/`. Frontend `vue-tsc --noEmit` and `vite build` clean.
- New `TestInboundTrafficSeedsThenAccumulates`: the seed counts only
  `resource='inbound'` (not user/outbound rows), is not windowed by time,
  accumulates a later flush on top, and returns a copy a caller cannot corrupt.
- Deployed to a live panel and checked end to end: `api/load` and the websocket
  push both carry `inboundTraffic` with the five values above, and the rendered
  cards match. The subscriber dashboard and the bare subscription URL were
  re-checked on the same build and are unaffected.
