### PR TITLE
fix(nodes): stop leaking idle HTTPS connections from short-lived clients

### DIFF
--- a/service/node.go
+++ b/service/node.go
@@ -57,6 +57,17 @@ const (
 	nodeProbeTimeout    = 4 * time.Second
 	nodeProbeParallel   = 8
 	nodeMaxResponseSize = 8 << 20
+
+	// A custom Transport inherits none of http.DefaultTransport's pool
+	// hygiene, and a zero IdleConnTimeout means an idle connection is held
+	// forever. Nothing reaps the Transport either — its readLoop goroutine
+	// keeps it reachable, so a dropped Transport is never collected — and the
+	// node panel's own http.Server sets no IdleTimeout, so without this
+	// neither end ever hangs up and every short-lived client costs one
+	// permanently ESTABLISHED socket (issue #176). Short-lived clients close
+	// their pool explicitly; this is the backstop for a path that forgets.
+	// Value mirrors http.DefaultTransport's.
+	nodeIdleConnTimeout = 90 * time.Second
 )
 
 type NodeService struct {
@@ -124,9 +135,29 @@ func buildNodeHTTPClient(n *model.Node) *http.Client {
 		} else if n.Insecure {
 			tlsConfig.InsecureSkipVerify = true
 		}
-		client.Transport = &http.Transport{TLSClientConfig: tlsConfig}
+		client.Transport = &http.Transport{
+			TLSClientConfig: tlsConfig,
+			IdleConnTimeout: nodeIdleConnTimeout,
+		}
 	}
 	return client
+}
+
+// closeIdle hands a node client's idle connections back.
+//
+// Not client.CloseIdleConnections() directly: buildNodeHTTPClient deliberately
+// leaves Transport nil for a plain-http node so it shares
+// http.DefaultTransport, and http.Client.CloseIdleConnections falls back to
+// that same default transport when Transport is nil. Calling it there would
+// empty a pool that belongs to every other caller in the process -- the update
+// check, warp, cmd/setting, notify without a proxy -- once a minute, for the
+// whole lifetime of one plain-http node. A shared pool needs no help from us:
+// it reaps itself on its own IdleConnTimeout.
+func closeIdle(client *http.Client) {
+	if client == nil || client.Transport == nil || client.Transport == http.DefaultTransport {
+		return
+	}
+	client.CloseIdleConnections()
 }
 
 func nodeHTTPClient(n *model.Node) *http.Client {
@@ -143,7 +174,13 @@ func nodeHTTPClient(n *model.Node) *http.Client {
 func invalidateNodeClient(id uint) {
 	nodeClientMu.Lock()
 	defer nodeClientMu.Unlock()
-	delete(nodeClients, id)
+	if client, ok := nodeClients[id]; ok {
+		// Dropping the map entry alone strands the Transport's idle
+		// connections for nodeIdleConnTimeout; the node's address or TLS mode
+		// just changed, so they are already useless.
+		closeIdle(client)
+		delete(nodeClients, id)
+	}
 }
 
 // nodeGet calls a remote panel's apiv2 GET action and unwraps the
@@ -396,7 +433,9 @@ func (s *NodeService) TestNode(data json.RawMessage) (NodeStatus, error) {
 		}
 		node.Token = oldToken
 	}
-	return s.probe(&node, buildNodeHTTPClient(&node)), nil
+	client := buildNodeHTTPClient(&node)
+	defer closeIdle(client)
+	return s.probe(&node, client), nil
 }
 
 // ---------- CRUD ----------

--- a/service/nodeSync.go
+++ b/service/nodeSync.go
@@ -154,6 +154,11 @@ type remoteInbound struct {
 
 // nodeClient builds a short-lived HTTP client honouring the node's TLS mode,
 // with the longer push timeout.
+//
+// Every caller must defer closeIdle: the client is short-lived but its
+// Transport's idle pool is not, and letting it fall out of scope leaks one
+// ESTABLISHED socket per call (issue #176 — see nodeIdleConnTimeout). Go
+// through closeIdle rather than the client's own method; it says why.
 func nodePushClient(n *model.Node) *http.Client {
 	c := buildNodeHTTPClient(n)
 	c.Timeout = nodePushTimeout
@@ -167,7 +172,9 @@ func (s *NodeSyncService) FetchNodeInbounds(nodeId uint) ([]remoteInbound, error
 	if err != nil {
 		return nil, err
 	}
-	obj, err := s.nodeGet(node, nodePushClient(node), "inbounds", nil)
+	client := nodePushClient(node)
+	defer closeIdle(client)
+	obj, err := s.nodeGet(node, client, "inbounds", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -220,6 +227,7 @@ func (s *NodeSyncService) AdoptInbounds(nodeId uint, tags []string, actor string
 		return err
 	}
 	client := nodePushClient(node)
+	defer closeIdle(client)
 
 	wanted := map[string]bool{}
 	for _, t := range tags {
@@ -414,6 +422,7 @@ func (s *NodeSyncService) runReconcile(nodeId uint, startGen uint64) error {
 		return common.NewError("node is disabled — enable it before syncing")
 	}
 	client := nodePushClient(node)
+	defer closeIdle(client)
 
 	// tag -> node-local inbound id
 	tagToId, err := s.nodeInboundTagMap(node, client)
@@ -906,6 +915,7 @@ func (s *NodeSyncService) CollectTraffic() {
 
 func (s *NodeSyncService) collectNodeTraffic(node *model.Node) error {
 	client := nodePushClient(node)
+	defer closeIdle(client)
 	current, err := s.actualClusterClients(node, client)
 	if err != nil {
 		return err

--- a/service/node_test.go
+++ b/service/node_test.go
@@ -1,0 +1,170 @@
+package service
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/shenaba/2s-ui/database"
+	"github.com/shenaba/2s-ui/database/model"
+)
+
+// TestBuildNodeHTTPClientBoundsIdleConns pins the backstop: a custom Transport
+// inherits none of http.DefaultTransport's pool settings, and a zero
+// IdleConnTimeout means an idle connection is never reaped. The node panel's
+// own http.Server sets no IdleTimeout either, so a zero here is one permanently
+// ESTABLISHED socket per client that forgets to close its pool (issue #176).
+func TestBuildNodeHTTPClientBoundsIdleConns(t *testing.T) {
+	client := buildNodeHTTPClient(&model.Node{BaseUrl: "https://node.example:2095", Insecure: true})
+	tr, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("https node: want a custom *http.Transport, got %T", client.Transport)
+	}
+	if tr.IdleConnTimeout <= 0 {
+		t.Fatalf("https node: IdleConnTimeout = %v, want a positive timeout", tr.IdleConnTimeout)
+	}
+
+	// Plain http deliberately leaves Transport nil so it shares
+	// http.DefaultTransport, which already bounds its own pool.
+	client = buildNodeHTTPClient(&model.Node{BaseUrl: "http://node.example:2095"})
+	if client.Transport != nil {
+		t.Fatalf("http node: want the default transport, got %T", client.Transport)
+	}
+}
+
+// closeIdle must not touch http.DefaultTransport. A plain-http node's client
+// has a nil Transport, and http.Client.CloseIdleConnections falls back to the
+// default transport when it does -- so calling it there empties a pool shared
+// with the update check, warp, cmd/setting and notify, once a minute for as
+// long as that node exists.
+func TestCloseIdleSparesTheSharedTransport(t *testing.T) {
+	var closed atomic.Int32
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"success":true,"obj":{}}`))
+	}))
+	srv.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateClosed {
+			closed.Add(1)
+		}
+	}
+	srv.Start()
+	defer srv.Close()
+
+	// Stand in for any other caller in the process: a client with no Transport
+	// of its own, leaving one connection in the shared pool.
+	shared := &http.Client{Timeout: 5 * time.Second}
+	resp, err := shared.Get(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+
+	closeIdle(buildNodeHTTPClient(&model.Node{BaseUrl: "http://node.example:2095"}))
+
+	// The teardown would be asynchronous, so give it the room it would need.
+	time.Sleep(200 * time.Millisecond)
+	if n := closed.Load(); n > 0 {
+		t.Fatalf("closeIdle tore down %d shared connection(s); it must skip a client with no Transport of its own", n)
+	}
+
+	// It still has to do its job for a client that does own its pool.
+	own := buildNodeHTTPClient(&model.Node{BaseUrl: "https://node.example:2095"})
+	if own.Transport == nil {
+		t.Fatal("https node should own its transport")
+	}
+	closeIdle(own) // must not panic, and must reach the client's own pool
+}
+
+// connCounter watches an httptest server's sockets so a test can ask how many
+// are still established.
+type connCounter struct {
+	mu   sync.Mutex
+	live map[net.Conn]bool
+	peak int
+}
+
+func (c *connCounter) state(conn net.Conn, state http.ConnState) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	switch state {
+	case http.StateNew:
+		c.live[conn] = true
+		if len(c.live) > c.peak {
+			c.peak = len(c.live)
+		}
+	case http.StateClosed, http.StateHijacked:
+		delete(c.live, conn)
+	}
+}
+
+// settle waits for the server to notice connections the client has hung up on
+// — ConnState fires asynchronously — and reports what is left.
+func (c *connCounter) settle(want int) (open int, peak int) {
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		c.mu.Lock()
+		open, peak = len(c.live), c.peak
+		c.mu.Unlock()
+		if open <= want || time.Now().After(deadline) {
+			return open, peak
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// TestNodeRequestsDoNotAccumulateConnections is the regression test for #176.
+// Every short-lived node client builds its own Transport, whose idle pool
+// outlives the client and is never collected, so repeated rounds used to leave
+// one ESTABLISHED socket behind each — roughly 1,400 per node per day from the
+// per-minute traffic collection alone. FetchNodeInbounds stands in for the
+// whole family: it is the shortest real path through nodePushClient.
+func TestNodeRequestsDoNotAccumulateConnections(t *testing.T) {
+	counter := &connCounter{live: map[net.Conn]bool{}}
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"success":true,"obj":{"inbounds":[]}}`))
+	}))
+	srv.Config.ConnState = counter.state
+	srv.StartTLS()
+	defer srv.Close()
+
+	// getNodeById reads the package-level handle, so the DB has to be
+	// installed globally; see TestExpectedClientsCarriesLimitIp for why the
+	// cleanup order matters on Windows.
+	dir := t.TempDir()
+	if err := database.InitDB(filepath.Join(dir, "test.db")); err != nil {
+		t.Fatalf("init db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := database.CloseDBForTest(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
+
+	node := model.Node{
+		Name: "n1", BaseUrl: srv.URL, WebPath: "/app/",
+		Token: "t", Insecure: true, Enable: true,
+	}
+	if err := database.GetDB().Create(&node).Error; err != nil {
+		t.Fatalf("seed node: %v", err)
+	}
+
+	var s NodeSyncService
+	const rounds = 15
+	for i := 0; i < rounds; i++ {
+		if _, err := s.FetchNodeInbounds(node.Id); err != nil {
+			t.Fatalf("round %d: %v", i, err)
+		}
+	}
+
+	if open, peak := counter.settle(0); open > 0 {
+		t.Fatalf("after %d rounds: %d connections still established (peak %d), want 0", rounds, open, peak)
+	}
+}

--- a/service/notify/notify.go
+++ b/service/notify/notify.go
@@ -298,10 +298,17 @@ func httpClient(proxy string) *http.Client {
 	if clientSet && clientProxy == proxy {
 		return clientCache
 	}
+	// The outgoing client is about to be replaced; its idle connections go
+	// through the proxy we are leaving, and a custom Transport holds them
+	// forever unless told otherwise (issue #176). Only ours — closing
+	// DefaultTransport's pool would reach every other caller in the process.
+	if clientCache != nil && clientCache.Transport != http.DefaultTransport {
+		clientCache.CloseIdleConnections()
+	}
 	transport := http.DefaultTransport
 	if proxy != "" {
 		if u, err := url.Parse(proxy); err == nil {
-			transport = &http.Transport{Proxy: http.ProxyURL(u)}
+			transport = &http.Transport{Proxy: http.ProxyURL(u), IdleConnTimeout: 90 * time.Second}
 		} else {
 			logger.Warning("notify: ignoring unparsable proxy ", proxy, ": ", err)
 		}

--- a/service/tgbot/bot.go
+++ b/service/tgbot/bot.go
@@ -101,9 +101,18 @@ func supervise(ctx context.Context) {
 // runSession blocks for as long as one connection lasts: until the panel shuts
 // down, until the bot is switched off, or until its credentials change.
 func runSession(ctx context.Context, cfg service.BotConfig) error {
+	// One client per session, and supervise starts a new session on every
+	// reconnect — so hand its idle connections back rather than leaving a
+	// custom Transport holding them for good (issue #176). Only ours: closing
+	// DefaultTransport's pool would reach every other caller in the process.
+	client := httpClient(cfg.Proxy)
+	if client.Transport != http.DefaultTransport {
+		defer client.CloseIdleConnections()
+	}
+
 	opts := []bot.Option{
 		bot.WithDefaultHandler(dispatch),
-		bot.WithHTTPClient(httpTimeout, httpClient(cfg.Proxy)),
+		bot.WithHTTPClient(httpTimeout, client),
 		// Only what is actually handled. Anything else is bandwidth spent on
 		// updates that get dropped, and Telegram keeps re-sending until the
 		// offset moves past them.
@@ -294,7 +303,7 @@ func httpClient(proxy string) *http.Client {
 	transport := http.DefaultTransport
 	if proxy != "" {
 		if u, err := url.Parse(proxy); err == nil {
-			transport = &http.Transport{Proxy: http.ProxyURL(u)}
+			transport = &http.Transport{Proxy: http.ProxyURL(u), IdleConnTimeout: 90 * time.Second}
 		} else {
 			logger.Warning("tgbot: ignoring unparsable proxy ", proxy, ": ", err)
 		}

--- a/util/subToJson.go
+++ b/util/subToJson.go
@@ -12,14 +12,21 @@ import (
 	"github.com/shenaba/2s-ui/util/common"
 )
 
-func GetExternalLink(url string) string {
-	tr := &http.Transport{
+// One client for the process, not one per call: a custom Transport holds its
+// idle connections forever (zero IdleConnTimeout) and is never collected, so
+// building one per call leaked a socket for every external link in every
+// subscription fetch (issue #176). Sharing it also lets repeat fetches of the
+// same upstream reuse a connection.
+var externalLinkClient = &http.Client{
+	Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
+		IdleConnTimeout: 90 * time.Second,
+	},
+	Timeout: 10 * time.Second,
+}
 
-	client := &http.Client{Transport: tr, Timeout: 10 * time.Second}
-
-	response, err := client.Get(url)
+func GetExternalLink(url string) string {
+	response, err := externalLinkClient.Get(url)
 	if err != nil {
 		logger.Warning("sub: Error making HTTP request:", err)
 		return ""


### PR DESCRIPTION
Fixes #176.

`buildNodeHTTPClient` gives an https node a custom `http.Transport`, which inherits none of `http.DefaultTransport`'s pool settings: its zero `IdleConnTimeout` keeps an idle connection forever, and the Transport itself is never collected, because its readLoop goroutine keeps it reachable. The node panel's own `http.Server` sets no `IdleTimeout` either, so neither end ever hangs up, and every short-lived client leaves one ESTABLISHED socket behind — about 1,400 per node per day from the per-minute traffic collection alone.

The reporter measured 1,702 connections to one node and 1,487 to another after 28 hours, 97.7% of that node's conntrack table, having previously lost a server to `nf_conntrack: table full`. Plain http nodes were never affected: they leave `Transport` nil and share `DefaultTransport`, which reaps its own pool.

## What changed

- The custom Transport carries `DefaultTransport`'s 90s `IdleConnTimeout` as a backstop.
- All five short-lived client sites hand their pool back: traffic collection, reconcile, inbound fetch, adoption and the node test button. `invalidateNodeClient` releases the cached client it drops rather than stranding it.
- They go through a `closeIdle` helper rather than `client.CloseIdleConnections()`, because that method is wrong for half the nodes: it falls back to `http.DefaultTransport` when `Transport` is nil, which is exactly what a plain-http node's client has. Calling it there would empty a pool shared with the update check, warp, `cmd/setting` and notify — once a minute, for as long as one plain-http node exists.
- Three other instances of the same defect: `util.GetExternalLink` built a Transport per call, so every external link in every subscription fetch leaked a socket (now one shared client); the notify and tgbot proxy clients dropped theirs on each settings change and bot reconnect (now released first, with the same `DefaultTransport` guard inline — those packages cannot reach `closeIdle` without an import cycle).

## Not done

Each collection round still opens a fresh connection, exactly as before — closing the pool is not a regression on that. Reusing one across rounds would mean sharing the cached client between the 4s probe path and the 15s push path, which needs per-request context deadlines instead of `Client.Timeout`. That is its own piece of work, and it buys one TLS handshake per minute per node.

## Testing

`TestNodeRequestsDoNotAccumulateConnections` drives `FetchNodeInbounds` against an `httptest` TLS server and counts the sockets the server still holds open: 15 rounds left 15 connections before this change, 0 after. `TestCloseIdleSparesTheSharedTransport` pins the `DefaultTransport` guard — the same scenario tears down a shared connection without it.

Full gate green locally: `go vet`, `go build`, `go test ./...`.
